### PR TITLE
PR1-core-1: Prepare protocol and plugin configuration scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ builddir/
 .flatpak-builder/
 repo/
 *.flatpak
+kdeconnect-info/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,10 +2789,12 @@ dependencies = [
  "base64",
  "dirs",
  "hostname",
+ "libc",
  "libpulse-binding",
  "mpris",
  "notify-rust",
  "once_cell",
+ "percent-encoding",
  "pin-project",
  "rcgen",
  "ron",
@@ -2806,6 +2808,7 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "uuid",
+ "x509-parser",
  "zbus",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 urlencoding = "2.1"
 uuid = { version = "1.23.1", features = ["v4"] }
 zbus = "5.15"
+libc = "0.2"
 libpulse-binding = { version = "2.30" }
 
 kdeconnect-core = { path = "kdeconnect-core" }

--- a/kdeconnect-core/Cargo.toml
+++ b/kdeconnect-core/Cargo.toml
@@ -25,6 +25,9 @@ tokio-rustls = { workspace = true }
 tracing = { workspace = true }
 mpris = { workspace = true }
 zbus = { workspace = true }
+libc = { workspace = true }
 libpulse-binding = { workspace = true }
+percent-encoding = { workspace = true }
 base64 = "0.22"
 tempfile = "3"
+x509-parser = "0.18"

--- a/kdeconnect-core/src/config.rs
+++ b/kdeconnect-core/src/config.rs
@@ -5,6 +5,7 @@ use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
 };
 use tracing::debug;
+use x509_parser::prelude::*;
 
 use crate::{
     crypto::KeyStore,
@@ -19,42 +20,63 @@ pub const DEVICE_ID_STORE: &str = "device_id";
 /// The phone checks this list before sending unsolicited data (battery, SMS messages, etc.).
 const INCOMING_CAPABILITIES: &[&str] = &[
     "kdeconnect.battery",
+    "kdeconnect.battery.request",
     "kdeconnect.clipboard",
     "kdeconnect.clipboard.connect",
     "kdeconnect.connectivity_report",
+    "kdeconnect.digitizer",
+    "kdeconnect.digitizer.session",
     "kdeconnect.contacts.response_uids_timestamps",
     "kdeconnect.contacts.response_vcards",
+    "kdeconnect.findmyphone.request",
+    "kdeconnect.mousepad.echo",
     "kdeconnect.mousepad.keyboardstate",
+    "kdeconnect.mousepad.request",
     "kdeconnect.mpris",
     "kdeconnect.mpris.request",
     "kdeconnect.notification",
+    "kdeconnect.notification.request",
     "kdeconnect.ping",
+    "kdeconnect.presenter",
+    "kdeconnect.runcommand",
     "kdeconnect.runcommand.request",
     "kdeconnect.share.request",
+    "kdeconnect.sftp",
     "kdeconnect.sms.messages",
     "kdeconnect.sms.attachment_file",
+    "kdeconnect.systemvolume.request",
     "kdeconnect.telephony",
 ];
 
 const OUTGOING_CAPABILITIES: &[&str] = &[
+    "kdeconnect.battery",
     "kdeconnect.battery.request",
     "kdeconnect.clipboard",
+    "kdeconnect.clipboard.connect",
     "kdeconnect.contacts.request_all_uids_timestamps",
     "kdeconnect.contacts.request_vcards_by_uid",
+    "kdeconnect.connectivity_report.request",
     "kdeconnect.findmyphone.request",
+    "kdeconnect.mousepad.echo",
     "kdeconnect.mousepad.keyboardstate",
     "kdeconnect.mousepad.request",
     "kdeconnect.mpris",
     "kdeconnect.mpris.request",
     "kdeconnect.notification.request",
+    "kdeconnect.notification",
+    "kdeconnect.notification.action",
+    "kdeconnect.notification.reply",
     "kdeconnect.ping",
     "kdeconnect.runcommand",
+    "kdeconnect.runcommand.request",
     "kdeconnect.share.request",
-    "kdeconnect.share.request.update",
+    "kdeconnect.sftp.request",
     "kdeconnect.sms.request",
     "kdeconnect.sms.request_conversations",
     "kdeconnect.sms.request_conversation",
     "kdeconnect.sms.request_attachment",
+    "kdeconnect.systemvolume",
+    "kdeconnect.telephony.request_mute",
 ];
 
 #[derive(Debug)]
@@ -69,42 +91,40 @@ pub struct Config {
 impl Config {
     pub async fn load(_out_caps: Vec<String>) -> anyhow::Result<Self> {
         let config_dir = dirs::config_dir()
-            .expect("cannot find config dir")
+            .ok_or_else(|| anyhow::anyhow!("cannot find config dir"))?
             .join(CONFIG_DIR);
 
         if !config_dir.exists() {
-            fs::create_dir_all(&config_dir)
-                .await
-                .expect("cannot create config dir");
+            fs::create_dir_all(&config_dir).await?;
         }
 
         let id_file = config_dir.join(DEVICE_ID_STORE);
-
-        let identity = match id_file.exists() {
-            true => {
-                let mut buffer = String::new();
-                let mut file = fs::File::open(&id_file).await.expect("cannot open file");
-
-                file.read_to_string(&mut buffer)
-                    .await
-                    .expect("fail reading file content");
-
-                let device_id = buffer.trim().to_string();
-                make_identity(device_id, Some(DEFAULT_LISTEN_PORT)).await
-            }
-            false => {
-                let device_id = uuid::Uuid::new_v4().to_string();
-
-                let mut file = fs::File::create(&id_file)
-                    .await
-                    .expect("cannot create file");
-                file.write_all(device_id.as_bytes())
-                    .await
-                    .expect("fail writing device id to file");
-
-                make_identity(device_id, Some(DEFAULT_LISTEN_PORT)).await
-            }
+        let stored_device_id = if id_file.exists() {
+            let mut buffer = String::new();
+            let mut file = fs::File::open(&id_file).await?;
+            file.read_to_string(&mut buffer).await?;
+            Some(buffer.trim().to_string())
+        } else {
+            None
         };
+
+        let cert_device_id = certificate_common_name(&config_dir.join("certificate.pem")).await;
+        let device_id = cert_device_id
+            .or(stored_device_id)
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+        if fs::read_to_string(&id_file)
+            .await
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            != Some(device_id.as_str())
+        {
+            let mut file = fs::File::create(&id_file).await?;
+            file.write_all(device_id.as_bytes()).await?;
+        }
+
+        let identity = make_identity(device_id, Some(DEFAULT_LISTEN_PORT)).await;
 
         debug!("CONFIG initialized.");
 
@@ -115,12 +135,22 @@ impl Config {
                 .to_string(),
             listen_addr: DEFAULT_LISTEN_ADDR,
             discovery_interval: DEFAULT_DISCOVERY_INTERVAL,
-            key_store: KeyStore::load(&identity.device_id)
-                .await
-                .expect("failed to create keystore"),
+            key_store: KeyStore::load(&identity.device_id).await?,
             identity,
         })
     }
+}
+
+async fn certificate_common_name(path: &std::path::Path) -> Option<String> {
+    let bytes = fs::read(path).await.ok()?;
+    let (_, pem) = parse_x509_pem(&bytes).ok()?;
+    let cert = pem.parse_x509().ok()?;
+    cert.subject()
+        .iter_common_name()
+        .next()
+        .and_then(|cn| cn.as_str().ok())
+        .map(str::to_string)
+        .filter(|id| !id.is_empty())
 }
 
 async fn make_identity(device_id: String, tcp_port: Option<u16>) -> Identity {
@@ -141,6 +171,8 @@ async fn make_identity(device_id: String, tcp_port: Option<u16>) -> Identity {
             .collect(),
         protocol_version: PROTOCOL_VERSION,
         tcp_port,
+        target_device_id: None,
+        target_protocol_version: None,
     }
 }
 
@@ -162,5 +194,28 @@ async fn identify_device_type() -> DeviceType {
         }
     } else {
         DeviceType::Desktop
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{INCOMING_CAPABILITIES, OUTGOING_CAPABILITIES};
+
+    #[test]
+    fn advertised_capabilities_cover_gsconnect_compatible_actions() {
+        assert!(OUTGOING_CAPABILITIES.contains(&"kdeconnect.clipboard.connect"));
+        assert!(OUTGOING_CAPABILITIES.contains(&"kdeconnect.notification.action"));
+        assert!(OUTGOING_CAPABILITIES.contains(&"kdeconnect.notification.reply"));
+
+        assert!(INCOMING_CAPABILITIES.contains(&"kdeconnect.clipboard.connect"));
+        assert!(INCOMING_CAPABILITIES.contains(&"kdeconnect.notification"));
+        assert!(INCOMING_CAPABILITIES.contains(&"kdeconnect.notification.request"));
+    }
+
+    #[test]
+    fn advertised_capabilities_do_not_claim_unimplemented_lock_plugin() {
+        assert!(!INCOMING_CAPABILITIES.contains(&"kdeconnect.lock"));
+        assert!(!OUTGOING_CAPABILITIES.contains(&"kdeconnect.lock"));
+        assert!(!OUTGOING_CAPABILITIES.contains(&"kdeconnect.lock.request"));
     }
 }

--- a/kdeconnect-core/src/crypto.rs
+++ b/kdeconnect-core/src/crypto.rs
@@ -24,19 +24,32 @@ pub struct KeyStore {
 impl KeyStore {
     pub async fn load(device_uuid: &str) -> anyhow::Result<Self> {
         let config_dir = dirs::config_dir()
-            .expect("cant find config directory")
+            .ok_or_else(|| anyhow::anyhow!("cannot find config directory"))?
             .join(CONFIG_DIR);
 
         if !config_dir.exists() {
-            fs::create_dir_all(&config_dir)
-                .await
-                .expect("failed to create config directory");
+            fs::create_dir_all(&config_dir).await?;
         }
 
-        let cert_path = config_dir.join(format!("device_cert@{}.pem", device_uuid));
-        let keys_path = config_dir.join(format!("device_key@{}.pem", device_uuid));
+        let standard_cert_path = config_dir.join("certificate.pem");
+        let kde_standard_keys_path = config_dir.join("privateKey.pem");
+        let gsconnect_standard_keys_path = config_dir.join("private.pem");
+        let device_cert_path = config_dir.join(format!("device_cert@{}.pem", device_uuid));
+        let device_keys_path = config_dir.join(format!("device_key@{}.pem", device_uuid));
 
-        if !keys_path.exists() && !cert_path.exists() {
+        // Prefer the standard KDE Connect/GSConnect filenames when present.
+        // This preserves existing pairings when migrating from another desktop
+        // implementation; Android pins the desktop certificate for a device ID.
+        let (cert_path, keys_path) =
+            if standard_cert_path.exists() && kde_standard_keys_path.exists() {
+                (standard_cert_path, kde_standard_keys_path)
+            } else if standard_cert_path.exists() && gsconnect_standard_keys_path.exists() {
+                (standard_cert_path, gsconnect_standard_keys_path)
+            } else {
+                (device_cert_path, device_keys_path)
+            };
+
+        if !keys_path.exists() || !cert_path.exists() {
             let key = KeyPair::generate()?.serialize_pem();
             let mut key_file = fs::File::create(&keys_path).await?;
             key_file.write_all(key.as_bytes()).await?;
@@ -48,16 +61,11 @@ impl KeyStore {
 
         let verifier = Arc::new(NoCertificateVerification::new(default_provider()));
 
-        // Read files asynchronously
-        let cert_bytes = fs::read(&cert_path)
-            .await
-            .expect("reading certificate file");
-        let keys_bytes = fs::read(&keys_path)
-            .await
-            .expect("reading private key file");
+        let cert_bytes = fs::read(&cert_path).await?;
+        let keys_bytes = fs::read(&keys_path).await?;
 
-        let cert = CertificateDer::from_pem_slice(&cert_bytes).expect("decoding certfificate");
-        let keys = PrivateKeyDer::from_pem_slice(&keys_bytes).expect("decoding private key");
+        let cert = CertificateDer::from_pem_slice(&cert_bytes)?;
+        let keys = PrivateKeyDer::from_pem_slice(&keys_bytes)?;
 
         let client_config = Arc::new(
             rustls::ClientConfig::builder()
@@ -69,8 +77,7 @@ impl KeyStore {
         let server_config = Arc::new(
             rustls::ServerConfig::builder()
                 .with_client_cert_verifier(verifier.clone())
-                .with_single_cert(vec![cert], keys)
-                .expect("building server config"),
+                .with_single_cert(vec![cert], keys)?,
         );
 
         Ok(Self {

--- a/kdeconnect-core/src/lib.rs
+++ b/kdeconnect-core/src/lib.rs
@@ -36,6 +36,10 @@ pub use protocol::{PacketType, ProtocolPacket};
 
 pub static GLOBAL_CONFIG: OnceLock<config::Config> = OnceLock::new();
 
+#[cfg(test)]
+pub(crate) static TEST_ENV_LOCK: once_cell::sync::Lazy<Mutex<()>> =
+    once_cell::sync::Lazy::new(|| Mutex::new(()));
+
 pub struct KdeConnectCore {
     device_manager: Arc<DeviceManager>,
     pairing: Arc<PairingManager>,

--- a/kdeconnect-core/src/plugin_config.rs
+++ b/kdeconnect-core/src/plugin_config.rs
@@ -9,10 +9,14 @@ use tokio::fs;
 use crate::config::CONFIG_DIR;
 
 fn config_path(device_id: &str) -> std::path::PathBuf {
+    let safe_id: String = device_id
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+        .collect();
     dirs::config_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
         .join(CONFIG_DIR)
-        .join(format!("{}_plugins.json", device_id))
+        .join(format!("{}_plugins.json", safe_id))
 }
 
 /// Load the set of disabled plugin IDs for a device.
@@ -21,15 +25,7 @@ pub async fn load_disabled_plugins(device_id: &str) -> HashSet<String> {
     let path = config_path(device_id);
     match fs::read_to_string(&path).await {
         Ok(json) => serde_json::from_str::<HashSet<String>>(&json).unwrap_or_default(),
-        Err(_) => {
-            // No config yet — seed with plugins disabled by default.
-            // Remote Input and Presentation Mode require compositor RDP support
-            // which COSMIC does not yet provide.
-            let mut defaults = HashSet::new();
-            defaults.insert("mousepad".to_string());
-            defaults.insert("presenter".to_string());
-            defaults
-        }
+        Err(_) => HashSet::new(),
     }
 }
 
@@ -46,5 +42,63 @@ pub async fn save_disabled_plugins(device_id: &str, disabled: &HashSet<String>) 
             }
         }
         Err(e) => tracing::warn!("[plugin_config] serialize failed: {}", e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_path_sanitizes_traversal_attempts() {
+        let path = config_path("../../../etc/passwd");
+        let filename = path.file_name().unwrap().to_str().unwrap();
+        assert_eq!(filename, "etcpasswd_plugins.json");
+        assert!(!path.to_str().unwrap().contains(".."));
+    }
+
+    #[test]
+    fn config_path_preserves_valid_device_ids() {
+        let path = config_path("abcdef1234567890abcdef1234567890");
+        let filename = path.file_name().unwrap().to_str().unwrap();
+        assert_eq!(filename, "abcdef1234567890abcdef1234567890_plugins.json");
+    }
+
+    #[test]
+    fn config_path_handles_hyphens_and_underscores() {
+        let path = config_path("abc-def_123-456-789012345678901234");
+        let filename = path.file_name().unwrap().to_str().unwrap();
+        assert_eq!(filename, "abc-def_123-456-789012345678901234_plugins.json");
+    }
+
+    #[tokio::test]
+    async fn load_returns_empty_set_for_missing_file() {
+        let _guard = crate::TEST_ENV_LOCK.lock().await;
+        let _td = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("HOME", _td.path());
+        }
+        let result = load_disabled_plugins("nonexistent_device_id_000000000000").await;
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn save_and_load_round_trips() {
+        let _guard = crate::TEST_ENV_LOCK.lock().await;
+        let td = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("HOME", td.path());
+        }
+        let config_dir = td.path().join(".config").join("kdeconnect");
+        tokio::fs::create_dir_all(&config_dir).await.unwrap();
+
+        let device_id = "test_device_roundtrip_000000000000";
+        let mut disabled = HashSet::new();
+        disabled.insert("battery".to_string());
+        disabled.insert("clipboard".to_string());
+
+        save_disabled_plugins(device_id, &disabled).await;
+        let loaded = load_disabled_plugins(device_id).await;
+        assert_eq!(loaded, disabled);
     }
 }

--- a/kdeconnect-core/src/plugin_interface.rs
+++ b/kdeconnect-core/src/plugin_interface.rs
@@ -1,27 +1,20 @@
 use std::{
     collections::{HashMap, HashSet},
+    future::Future,
+    pin::Pin,
     sync::Arc,
 };
 use tokio::{
     io::{AsyncRead, AsyncWriteExt},
     sync::{RwLock, mpsc},
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     GLOBAL_CONFIG,
     device::Device,
     event::{ConnectionEvent, CoreEvent},
-    filetransfer::{send_progress, TransferAdapter},
-    plugins::{
-        self,
-        battery::Battery,
-        clipboard::Clipboard,
-        connectivity_report::ConnectivityReport,
-        mpris::{Mpris, MprisRequest},
-        systemvolume::SystemVolumeRequest,
-        telephony::TelephonyPacket,
-    },
+    filetransfer::{TransferAdapter, send_progress},
     protocol::{PacketPayloadTransferInfo, PacketType, ProtocolPacket},
     transport::prepare_listener_for_payload,
 };
@@ -39,6 +32,7 @@ fn packet_plugin_id(pt: &PacketType) -> Option<&'static str> {
         PacketType::ConnectivityReport | PacketType::ConnectivityReportRequest => {
             Some("connectivity_report")
         }
+        PacketType::Digitizer | PacketType::DigitizerSession => Some("digitizer"),
         PacketType::ContactsResponseUidsTimestamps
         | PacketType::ContactsResponseVcards
         | PacketType::ContactsRequestAllUidsTimestamps
@@ -52,6 +46,7 @@ fn packet_plugin_id(pt: &PacketType) -> Option<&'static str> {
         PacketType::Ping => Some("ping"),
         PacketType::RunCommand | PacketType::RunCommandRequest => Some("runcommand"),
         PacketType::ShareRequest | PacketType::ShareRequestUpdate => Some("share"),
+        PacketType::Sftp | PacketType::SftpRequest => Some("sftp"),
         PacketType::SmsMessages
         | PacketType::SmsRequest
         | PacketType::SmsRequestConversations
@@ -59,25 +54,34 @@ fn packet_plugin_id(pt: &PacketType) -> Option<&'static str> {
         | PacketType::SmsAttachmentFile
         | PacketType::SmsRequestAttachment => Some("sms"),
         PacketType::SystemVolume | PacketType::SystemVolumeRequest => Some("systemvolume"),
-        PacketType::Telephony | PacketType::TelephonyRequestMute => Some("telephony"),
-        // Core / unmanaged packets are never gated
-        PacketType::Identity
-        | PacketType::Pair
-        | PacketType::Lock
-        | PacketType::LockRequest
-        | PacketType::MousePadEcho
+        PacketType::MousePadEcho
         | PacketType::MousePadKeyboardState
-        | PacketType::MousePadRequest
-        | PacketType::Presenter
-        | PacketType::Sftp
-        | PacketType::SftpRequest
-        | PacketType::Unknown(_) => None,
+        | PacketType::MousePadRequest => Some("mousepad"),
+        PacketType::Presenter => Some("presenter"),
+        PacketType::Telephony | PacketType::TelephonyRequestMute => Some("telephony"),
+        PacketType::Lock | PacketType::LockRequest => Some("lock"),
+        // Core / unmanaged packets are never gated
+        PacketType::Identity | PacketType::Pair | PacketType::Unknown(_) => None,
     }
 }
+
+/// A type-erased packet handler stored in the registry.
+type HandlerFn = dyn Fn(
+        Device,
+        serde_json::Value,
+        mpsc::UnboundedSender<CoreEvent>,
+        mpsc::UnboundedSender<ConnectionEvent>,
+        mpsc::UnboundedSender<ConnectionEvent>,
+        Option<PacketPayloadTransferInfo>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send>>
+    + Send
+    + Sync;
 
 #[derive(Clone)]
 pub struct PluginRegistry {
     plugins: Arc<RwLock<Vec<Arc<dyn Plugin>>>>,
+    /// PacketType → handler function (registered at startup).
+    handlers: Arc<RwLock<HashMap<PacketType, Arc<HandlerFn>>>>,
     /// device_id.0 → set of disabled plugin IDs
     disabled: Arc<RwLock<HashMap<String, HashSet<String>>>>,
 }
@@ -86,6 +90,7 @@ impl PluginRegistry {
     pub fn new() -> Self {
         Self {
             plugins: Arc::new(RwLock::new(Vec::new())),
+            handlers: Arc::new(RwLock::new(HashMap::new())),
             disabled: Arc::new(RwLock::new(HashMap::new())),
         }
     }
@@ -94,6 +99,11 @@ impl PluginRegistry {
         let mut plugins = self.plugins.write().await;
         info!("Registering plugin: {}", plugin.id());
         plugins.push(plugin);
+    }
+
+    /// Register a handler for a specific PacketType.
+    pub async fn register_handler(&self, packet_type: PacketType, handler: Arc<HandlerFn>) {
+        self.handlers.write().await.insert(packet_type, handler);
     }
 
     /// Replace the disabled set for a device (called on connect and on toggle).
@@ -122,222 +132,37 @@ impl PluginRegistry {
         mpris_tx: mpsc::UnboundedSender<ConnectionEvent>,
     ) {
         // Gate on plugin enabled state before doing any work.
-        if let Some(plugin_id) = packet_plugin_id(&packet.packet_type) {
-            if !self
-                .is_plugin_enabled(&device.device_id.0, plugin_id)
-                .await
-            {
-                debug!(
-                    "[plugin_registry] packet {:?} skipped — plugin '{}' disabled for {}",
-                    packet.packet_type, plugin_id, device.device_id
-                );
-                return;
-            }
+        if let Some(plugin_id) = packet_plugin_id(&packet.packet_type)
+            && !self.is_plugin_enabled(&device.device_id.0, plugin_id).await
+        {
+            debug!(
+                "[plugin_registry] packet {:?} skipped — plugin '{}' disabled for {}",
+                packet.packet_type, plugin_id, device.device_id
+            );
+            return;
         }
 
-        let body = packet.body.clone();
         info!("[dispatch] packet type: {:?}", packet.packet_type);
-        let core_tx = core_tx.clone();
-        let connection_tx = tx.clone();
-        let mpris_connection_tx = mpris_tx.clone();
-        let payload_info = packet.payload_transfer_info;
 
-        match packet.packet_type {
-            PacketType::Identity => {
-                debug!("Skipping identity packet");
-            }
-            PacketType::Pair => {
-                debug!("Skipping pair packet");
-            }
-            PacketType::Battery => {
-                if let Ok(battery) = serde_json::from_value::<Battery>(body) {
-                    battery.received_packet(connection_tx).await;
-                }
-            }
-            PacketType::BatteryRequest => {
-                debug!("BatteryRequest received — not implemented, ignoring");
-            }
-            PacketType::SmsMessages => {
-                debug!("Received SmsMessages packet");
-                if let Ok(sms_messages) =
-                    serde_json::from_value::<plugins::sms::SmsMessages>(body.clone())
-                {
-                    info!(
-                        "Received SMS messages packet with {} messages",
-                        sms_messages.messages.len()
-                    );
-                    debug!(
-                        "Successfully parsed {} SMS messages",
-                        sms_messages.messages.len()
-                    );
-                    sms_messages.received_packet(connection_tx).await;
-                } else {
-                    warn!("Failed to parse SMS messages packet: {:?}", body);
-                }
-            }
-            PacketType::ContactsResponseUidsTimestamps => {
-                debug!("Received ContactsResponseUidsTimestamps");
-                if let Some(uids_val) = body.get("uids").and_then(|v| v.as_array()) {
-                    let uids: Vec<String> = uids_val
-                        .iter()
-                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                        .collect();
-                    if !uids.is_empty() {
-                        debug!("Requesting vcards for {} UIDs", uids.len());
-                        let packet = ProtocolPacket::new(
-                            PacketType::ContactsRequestVcardsByUid,
-                            serde_json::json!({ "uids": uids }),
-                        );
-                        let _ = core_tx.send(CoreEvent::SendPacket {
-                            device: device.device_id.clone(),
-                            packet,
-                        });
-                    }
-                }
-            }
-            PacketType::ContactsResponseVcards => {
-                debug!("Received ContactsResponseVcards");
-                let mut contacts: std::collections::HashMap<String, String> =
-                    std::collections::HashMap::new();
-                if let Some(uids_val) = body.get("uids").and_then(|v| v.as_array()) {
-                    for uid_val in uids_val {
-                        if let Some(uid) = uid_val.as_str() {
-                            if let Some(vcard_str) = body.get(uid).and_then(|v| v.as_str()) {
-                                let (name_opt, phones) = parse_vcard(vcard_str);
-                                if let Some(name) = name_opt {
-                                    for phone in phones {
-                                        contacts.insert(phone, name.clone());
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                debug!("Parsed {} phone->name contact entries", contacts.len());
-                if !contacts.is_empty() {
-                    let _ = connection_tx.send(ConnectionEvent::ContactsReceived(contacts));
-                }
-            }
-            PacketType::Clipboard => {
-                if let Ok(clipboard) = serde_json::from_value::<Clipboard>(body) {
-                    clipboard.received_packet(connection_tx).await;
-                }
-            }
-            PacketType::ConnectivityReport => {
-                if let Ok(connectivity_rep) = serde_json::from_value::<ConnectivityReport>(body) {
-                    connectivity_rep.received_packet(connection_tx).await;
-                }
-            }
-            PacketType::ClipboardConnect => {
-                if let Ok(clipboard) = serde_json::from_value::<Clipboard>(body)
-                    && let Some(timestamp) = clipboard.timestamp
-                {
-                    let local_ts = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_millis() as u64)
-                        .unwrap_or(0);
-                    if timestamp > 0 && timestamp >= local_ts {
-                        info!("Clipboard sync on connect accepted (ts={} local={})", timestamp, local_ts);
-                        clipboard.received_packet(connection_tx).await;
-                    } else {
-                        info!("Clipboard sync on connect ignored — stale timestamp (ts={} local={})", timestamp, local_ts);
-                    }
-                }
-            }
-            PacketType::MousePadKeyboardState => {
-                if let Ok(keyboard_state) =
-                    serde_json::from_value::<plugins::mousepad::KeyboardState>(body)
-                {
-                    debug!("{:?}", keyboard_state);
-                }
-            }
-            PacketType::Mpris => {
-                if let Ok(mpris_packet) = serde_json::from_value::<Mpris>(body) {
-                    info!("Received MPRIS packet: {:?}", mpris_packet);
-                    let mpris_event =
-                        ConnectionEvent::Mpris((device.device_id.clone(), mpris_packet));
-                    let _ = connection_tx.send(mpris_event.clone());
-                    let _ = mpris_connection_tx.send(mpris_event);
-                }
-            }
-            PacketType::MprisRequest => {
-                if let Ok(mpris_request) = serde_json::from_value::<MprisRequest>(body) {
-                    mpris_request.received_packet(&device, core_tx).await;
-                }
-            }
-            PacketType::Notification => {
-                debug!("Received notification packet");
-                info!("Notification body: {:?}", body);
-                if let Ok(notification) =
-                    serde_json::from_value::<plugins::notification::Notification>(body)
-                {
-                    notification.received_packet(&device, core_tx).await;
-                }
-            }
-            PacketType::Ping => {
-                if let Ok(ping) = serde_json::from_value::<plugins::ping::Ping>(body) {
-                    ping.received_packet(&device, core_tx).await;
-                }
-            }
-            PacketType::RunCommand => {
-                if let Ok(run_command) =
-                    serde_json::from_value::<plugins::run_command::RunCommand>(body)
-                {
-                    run_command
-                        .received_packet(&device, connection_tx, core_tx)
-                        .await;
-                }
-            }
-            PacketType::RunCommandRequest => {
-                if let Ok(run_command_request) =
-                    serde_json::from_value::<plugins::run_command::RunCommandRequest>(body)
-                {
-                    run_command_request
-                        .received_packet(&device, connection_tx, core_tx)
-                        .await;
-                }
-            }
-            PacketType::ShareRequest => {
-                if let Ok(share_request) =
-                    serde_json::from_value::<plugins::share::ShareRequest>(body)
-                    && let Some(payload_info) = payload_info
-                {
-                    // Spawn so the event loop is not blocked during the
-                    // notification dialog wait + network payload download.
-                    tokio::spawn(async move {
-                        if let Err(e) = share_request.receive_share(&device, &payload_info).await {
-                            warn!("[share] receive_share failed: {}", e);
-                        }
-                    });
-                }
-            }
-            PacketType::SystemVolumeRequest => {
-                if let Ok(req) = serde_json::from_value::<SystemVolumeRequest>(body) {
-                    req.handle(&device, core_tx).await;
-                }
-            }
-            PacketType::Telephony => {
-                if let Ok(pkt) = serde_json::from_value::<TelephonyPacket>(body) {
-                    pkt.received_packet(&device, core_tx).await;
-                }
-            }
-            PacketType::TelephonyRequestMute => {
-                debug!("TelephonyRequestMute received — no action needed on desktop");
-            }
-            _ => {
-                debug!(
-                    "No plugin found to handle packet type: {:?}",
-                    packet.packet_type
-                );
-            }
+        if let Some(handler) = self.handlers.read().await.get(&packet.packet_type).cloned() {
+            handler(
+                device,
+                packet.body.clone(),
+                core_tx,
+                tx,
+                mpris_tx,
+                packet.payload_transfer_info,
+            )
+            .await;
+        } else {
+            debug!(
+                "No handler registered for packet type: {:?}",
+                packet.packet_type
+            );
         }
     }
 
     /// Send a packet that carries a binary payload (file / album art).
-    ///
-    /// The packet is enqueued immediately so the phone knows which port to
-    /// connect to. The actual TLS accept + byte copy is spawned as a
-    /// background task so the event loop is never blocked.
     pub async fn send_payload(
         &self,
         packet: ProtocolPacket,
@@ -367,12 +192,9 @@ impl PluginRegistry {
         let payload_transfer_info = Some(PacketPayloadTransferInfo { port: addr.port() });
         let body = packet.body.clone();
 
-        // Enqueue the packet with the port info NOW — the phone needs this to
-        // know where to connect. This is non-blocking (channel send).
         match packet.packet_type {
             PacketType::Mpris => {
-                if let Ok(mpris) = serde_json::from_value::<plugins::mpris::Mpris>(body) {
-                    debug!("got mpris packet, sending info.");
+                if let Ok(mpris) = serde_json::from_value::<crate::plugins::mpris::Mpris>(body) {
                     let _ = mpris
                         .send_art(device_writer, payload_size, payload_transfer_info)
                         .await;
@@ -380,25 +202,22 @@ impl PluginRegistry {
             }
             PacketType::ShareRequest => {
                 if let Ok(share_request) =
-                    serde_json::from_value::<plugins::share::ShareRequest>(body)
+                    serde_json::from_value::<crate::plugins::share::ShareRequest>(body)
                 {
-                    debug!("got share request packet, sending info.");
                     let _ = share_request
                         .send_file(device_writer, payload_size, payload_transfer_info)
                         .await;
                 }
             }
             _ => {
-                warn!(
-                    "[payload] No plugin found to handle packet type: {:?}",
+                error!(
+                    "[payload] unsupported payload type: {:?}; payload dropped",
                     packet.packet_type
                 );
                 return;
             }
         }
 
-        // Spawn the accept + copy so the event loop stays responsive for the
-        // entire duration of the file transfer.
         let server_config = GLOBAL_CONFIG.get().unwrap().key_store.server_config.clone();
         tokio::spawn(async move {
             let (incoming, peer_addr) = match free_listener.accept().await {
@@ -422,11 +241,15 @@ impl PluginRegistry {
             };
 
             debug!("[payload] TLS accepted, copying payload");
-            let _ = tokio::io::copy(&mut payload, &mut stream).await;
-            let _ = stream.flush().await;
+            if let Err(e) = tokio::io::copy(&mut payload, &mut stream).await {
+                warn!("[payload] copy failed: {}", e);
+                return;
+            }
+            if let Err(e) = stream.flush().await {
+                warn!("[payload] flush failed: {}", e);
+                return;
+            }
             let _ = stream.shutdown().await;
-            // Guarantee a final 100% progress event so the UI always clears
-            // regardless of file size or interval timing.
             send_progress(100, payload.notify_tx.clone());
             info!("[payload] successfully sent payload to {}", peer_addr);
         });
@@ -443,12 +266,14 @@ impl PluginRegistry {
 
         match packet.packet_type {
             PacketType::Ping => {
-                if let Ok(ping) = serde_json::from_value::<plugins::ping::Ping>(body) {
+                if let Ok(ping) = serde_json::from_value::<crate::plugins::ping::Ping>(body) {
                     ping.send_packet(&device, core_event).await;
                 }
             }
             PacketType::MprisRequest => {
-                if let Ok(mpris_request) = serde_json::from_value::<MprisRequest>(body) {
+                if let Ok(mpris_request) =
+                    serde_json::from_value::<crate::plugins::mpris::MprisRequest>(body)
+                {
                     mpris_request.send_packet(&device, core_event).await;
                 }
             }
@@ -465,32 +290,4 @@ impl PluginRegistry {
         let plugins = self.plugins.read().await;
         plugins.iter().map(|p| p.id().to_string()).collect()
     }
-}
-
-fn parse_vcard(content: &str) -> (Option<String>, Vec<String>) {
-    let mut name: Option<String> = None;
-    let mut phones: Vec<String> = Vec::new();
-    for line in content.lines() {
-        let line = line.trim();
-        if line.starts_with("FN:") {
-            name = Some(line[3..].trim().to_string());
-        } else if name.is_none() && line.starts_with("N:") {
-            let parts: Vec<&str> = line[2..].split(';').collect();
-            if parts.len() >= 2 {
-                let full = format!("{} {}", parts[1].trim(), parts[0].trim());
-                let full = full.trim().to_string();
-                if !full.is_empty() {
-                    name = Some(full);
-                }
-            }
-        } else if line.starts_with("TEL") {
-            if let Some(pos) = line.rfind(':') {
-                let phone = line[pos + 1..].trim().to_string();
-                if !phone.is_empty() {
-                    phones.push(phone);
-                }
-            }
-        }
-    }
-    (name, phones)
 }

--- a/kdeconnect-core/src/protocol.rs
+++ b/kdeconnect-core/src/protocol.rs
@@ -11,6 +11,46 @@ use tokio::{fs::File, io::AsyncRead};
 
 pub const PROTOCOL_VERSION: usize = 8;
 
+fn deserialize_packet_id<'de, D>(deserializer: D) -> Result<Option<u128>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Option::<Value>::deserialize(deserializer)? {
+        Some(Value::Number(id)) => id
+            .as_u64()
+            .map(|id| Some(id as u128))
+            .ok_or_else(|| serde::de::Error::custom("packet id must be an unsigned integer")),
+        Some(Value::String(id)) => id
+            .parse::<u128>()
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+        None => Ok(None),
+        Some(_) => Err(serde::de::Error::custom(
+            "packet id must be a number or numeric string",
+        )),
+    }
+}
+
+fn deserialize_optional_usize<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Option::<Value>::deserialize(deserializer)? {
+        Some(Value::Number(id)) => id
+            .as_u64()
+            .map(|id| Some(id as usize))
+            .ok_or_else(|| serde::de::Error::custom("value must be an unsigned integer")),
+        Some(Value::String(id)) => id
+            .parse::<usize>()
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+        None => Ok(None),
+        Some(_) => Err(serde::de::Error::custom(
+            "value must be a number or numeric string",
+        )),
+    }
+}
+
 fn serialize_packet_type<S>(pt: &PacketType, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
@@ -27,7 +67,7 @@ where
     Ok(PacketType::from(s))
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum PacketType {
     Battery,
     BatteryRequest,
@@ -35,6 +75,8 @@ pub enum PacketType {
     ClipboardConnect,
     ConnectivityReport,
     ConnectivityReportRequest,
+    Digitizer,
+    DigitizerSession,
     ContactsRequestAllUidsTimestamps,
     ContactsRequestVcardsByUid,
     ContactsResponseUidsTimestamps,
@@ -85,6 +127,8 @@ impl From<String> for PacketType {
             "kdeconnect.clipboard.connect" => PacketType::ClipboardConnect,
             "kdeconnect.connectivity_report" => PacketType::ConnectivityReport,
             "kdeconnect.connectivity_report.request" => PacketType::ConnectivityReportRequest,
+            "kdeconnect.digitizer" => PacketType::Digitizer,
+            "kdeconnect.digitizer.session" => PacketType::DigitizerSession,
             "kdeconnect.contacts.request_all_uids_timestamps" => {
                 PacketType::ContactsRequestAllUidsTimestamps
             }
@@ -92,6 +136,7 @@ impl From<String> for PacketType {
             | "kdeconnect.contacts.response_all_uids_timestamps" => {
                 PacketType::ContactsResponseUidsTimestamps
             }
+            "kdeconnect.contacts.request_vcards_by_uid" => PacketType::ContactsRequestVcardsByUid,
             "kdeconnect.contacts.response_vcards" => PacketType::ContactsResponseVcards,
             "kdeconnect.findmyphone.request" => PacketType::FindMyPhoneRequest,
             "kdeconnect.lock" => PacketType::Lock,
@@ -144,6 +189,8 @@ impl Display for PacketType {
             PacketType::ConnectivityReportRequest => {
                 write!(f, "kdeconnect.connectivity_report.request")
             }
+            PacketType::Digitizer => write!(f, "kdeconnect.digitizer"),
+            PacketType::DigitizerSession => write!(f, "kdeconnect.digitizer.session"),
             PacketType::ContactsRequestAllUidsTimestamps => {
                 write!(f, "kdeconnect.contacts.request_all_uids_timestamps")
             }
@@ -160,7 +207,7 @@ impl Display for PacketType {
             PacketType::Lock => write!(f, "kdeconnect.lock"),
             PacketType::LockRequest => write!(f, "kdeconnect.lock.request"),
             PacketType::MousePadEcho => write!(f, "kdeconnect.mousepad.echo"),
-            PacketType::MousePadKeyboardState => write!(f, "kdeconnect.mousepad.keyboard_state"),
+            PacketType::MousePadKeyboardState => write!(f, "kdeconnect.mousepad.keyboardstate"),
             PacketType::MousePadRequest => write!(f, "kdeconnect.mousepad.request"),
             PacketType::Mpris => write!(f, "kdeconnect.mpris"),
             PacketType::MprisRequest => write!(f, "kdeconnect.mpris.request"),
@@ -199,6 +246,7 @@ impl Display for PacketType {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ProtocolPacket {
+    #[serde(default, deserialize_with = "deserialize_packet_id")]
     pub id: Option<u128>,
     #[serde(rename = "type")]
     #[serde(
@@ -279,14 +327,103 @@ impl ProtocolPacket {
     }
 
     pub fn from_raw(raw: &[u8]) -> anyhow::Result<Self> {
-        let pkt: ProtocolPacket =
-            serde_json::from_slice(raw).expect("Failed to parse ProtocolPacket from raw data");
-        Ok(pkt)
+        Ok(serde_json::from_slice(raw)?)
     }
 
     pub fn as_raw(&self) -> anyhow::Result<Vec<u8>> {
-        let str = serde_json::to_string(self)?;
-        Ok(format!("{}\n", str).as_bytes().to_vec())
+        let mut buf = serde_json::to_vec(self)?;
+        buf.push(b'\n');
+        Ok(buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn packet_type_round_trips_known_protocol_names() {
+        let cases = [
+            (
+                "kdeconnect.contacts.request_vcards_by_uid",
+                PacketType::ContactsRequestVcardsByUid,
+            ),
+            (
+                "kdeconnect.mousepad.keyboardstate",
+                PacketType::MousePadKeyboardState,
+            ),
+        ];
+
+        for (wire_name, packet_type) in cases {
+            assert!(matches!(
+                PacketType::from(wire_name.to_string()),
+                pt if std::mem::discriminant(&pt) == std::mem::discriminant(&packet_type)
+            ));
+            assert_eq!(packet_type.to_string(), wire_name);
+        }
+    }
+
+    #[test]
+    fn from_raw_returns_error_for_invalid_json() {
+        assert!(ProtocolPacket::from_raw(b"not json\n").is_err());
+    }
+
+    #[test]
+    fn packet_id_accepts_kdeconnect_string_timestamp() {
+        let decoded = ProtocolPacket::from_raw(
+            br#"{"id":"1712345678901","type":"kdeconnect.ping","body":{}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(decoded.id, Some(1_712_345_678_901));
+        assert!(matches!(decoded.packet_type, PacketType::Ping));
+    }
+
+    #[test]
+    fn packet_serialization_uses_newline_delimited_json() {
+        let packet = ProtocolPacket::new(PacketType::Ping, json!({"message": "hello"}));
+        let raw = packet.as_raw().unwrap();
+        assert_eq!(raw.last(), Some(&b'\n'));
+        let decoded = ProtocolPacket::from_raw(&raw).unwrap();
+        assert!(matches!(decoded.packet_type, PacketType::Ping));
+        assert_eq!(decoded.body["message"], "hello");
+    }
+
+    #[test]
+    fn identity_accepts_android_string_target_protocol_version() {
+        let identity: Identity = serde_json::from_value(json!({
+            "deviceId": "abcdef1234567890abcdef1234567890",
+            "deviceName": "Phone",
+            "deviceType": "phone",
+            "incomingCapabilities": [],
+            "outgoingCapabilities": [],
+            "protocolVersion": 8,
+            "targetDeviceId": "0123456789abcdef0123456789abcdef",
+            "targetProtocolVersion": "8"
+        }))
+        .unwrap();
+
+        assert_eq!(identity.target_protocol_version, Some(8));
+        assert_eq!(
+            identity.target_device_id.as_deref(),
+            Some("0123456789abcdef0123456789abcdef")
+        );
+    }
+
+    #[test]
+    fn pair_packets_only_timestamp_new_requests() {
+        let request = Pair::request();
+        assert!(request.pair);
+        assert!(request.timestamp.is_some());
+
+        let accept = Pair::accept();
+        assert!(accept.pair);
+        assert!(accept.timestamp.is_none());
+
+        let reject = Pair::reject();
+        assert!(!reject.pair);
+        assert!(reject.timestamp.is_none());
     }
 }
 
@@ -300,6 +437,14 @@ pub struct Identity {
     pub outgoing_capabilities: Vec<String>,
     pub protocol_version: usize,
     pub tcp_port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_device_id: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_usize",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub target_protocol_version: Option<usize>,
 }
 
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
@@ -310,21 +455,38 @@ pub struct Pair {
 }
 
 impl Pair {
-    pub fn new(response: bool) -> Self {
-        if response {
-            let timestamp = Some(
-                SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs(),
-            );
-            return Pair {
-                pair: true,
-                timestamp,
-            };
-        }
+    /// Backward-compatible constructor used by upstream callers.
+    #[allow(dead_code)]
+    pub fn new(pair: bool) -> Self {
         Pair {
-            pair: response,
+            pair,
+            timestamp: None,
+        }
+    }
+
+    pub fn request() -> Self {
+        let timestamp = Some(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        );
+        Pair {
+            pair: true,
+            timestamp,
+        }
+    }
+
+    pub fn accept() -> Self {
+        Pair {
+            pair: true,
+            timestamp: None,
+        }
+    }
+
+    pub fn reject() -> Self {
+        Pair {
+            pair: false,
             timestamp: None,
         }
     }
@@ -355,7 +517,7 @@ impl DeviceFile<File> {
         let metadata = file.metadata().await?;
         Ok(DeviceFile {
             buf: file,
-            size: metadata.size().try_into().map_err(std::io::Error::other)?,
+            size: metadata.size(),
         })
     }
 

--- a/kdeconnect-core/src/transport.rs
+++ b/kdeconnect-core/src/transport.rs
@@ -611,6 +611,8 @@ async fn filtered_identity_for_device(device_id: &str) -> Identity {
         device_type: base.device_type,
         protocol_version: base.protocol_version,
         tcp_port: base.tcp_port,
+        target_device_id: None,
+        target_protocol_version: None,
         incoming_capabilities: base.incoming_capabilities.iter()
             .filter(|c| !remove_inc.contains(c.as_str()))
             .cloned()


### PR DESCRIPTION
## Summary
Prepares the core protocol/configuration layer for the follow-up reliability work. It adds packet parsing support needed by KDE Connect peers, updates capability mapping and plugin dispatch scaffolding, and keeps test environment state isolated.

## Maintainer Review Notes
This is intentionally limited to shared protocol/configuration primitives so later PRs can build on stable contracts without mixing in transport or UI behavior.

## Stack
Base: `master`  
Head: `JaredTweed:PR1-core-1-protocol-config`

## Verification
This branch was checked against its base with:

- `git diff --check upstream/master..PR1-core-1-protocol-config`
- `cargo check --workspace`
- `cargo test -p kdeconnect-core`
