### PR TITLE
PR1-core-6: Align core plugin handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ builddir/
 .flatpak-builder/
 repo/
 *.flatpak
+kdeconnect-info/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,10 +2789,12 @@ dependencies = [
  "base64",
  "dirs",
  "hostname",
+ "libc",
  "libpulse-binding",
  "mpris",
  "notify-rust",
  "once_cell",
+ "percent-encoding",
  "pin-project",
  "rcgen",
  "ron",
@@ -2806,6 +2808,7 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "uuid",
+ "x509-parser",
  "zbus",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 urlencoding = "2.1"
 uuid = { version = "1.23.1", features = ["v4"] }
 zbus = "5.15"
+libc = "0.2"
 libpulse-binding = { version = "2.30" }
 
 kdeconnect-core = { path = "kdeconnect-core" }

--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@
 - Plugin Enable / Disable per device
 - System Volume (Partial support - May not work on certain devices - Known Mobile App Bug)
 - Telephony (Know bug - Media does not resume when Ending/Canceling Call)
+- MousePad / Remote Input
+- Presenter Mode
+- SFTP / Browse Device
 
 </details>
 
 <details>
 <summary>🚧 Features Not Yet Supported</summary>
 
-- MousePad / Remote Input
-- Presenter Mode
-- SFTP / Browse Device
 - Virtual Display
 
 </details>
@@ -69,6 +69,11 @@ just install
 ```
 
 The service starts automatically on next login via D-Bus activation and XDG autostart.
+
+Once it is installed, you can easily apply your updates to your desktop with this singular command without having to log out:
+```bash
+cargo fmt && cargo test --workspace && cargo check --workspace && just build && just install && just restart
+```
 
 ### Optional: Systemd Integration
 
@@ -144,6 +149,3 @@ sudo iptables -A OUTPUT -o <yourinterface> -p tcp --sport 1714:1764 -m state --s
 ```
 
 For more, directly from official KDEConnect userbase: [KDEConnect Firewall](https://userbase.kde.org/KDEConnect#ufw)
-
-
-

--- a/kdeconnect-core/Cargo.toml
+++ b/kdeconnect-core/Cargo.toml
@@ -25,6 +25,9 @@ tokio-rustls = { workspace = true }
 tracing = { workspace = true }
 mpris = { workspace = true }
 zbus = { workspace = true }
+libc = { workspace = true }
 libpulse-binding = { workspace = true }
+percent-encoding = { workspace = true }
 base64 = "0.22"
 tempfile = "3"
+x509-parser = "0.18"

--- a/kdeconnect-core/src/config.rs
+++ b/kdeconnect-core/src/config.rs
@@ -5,6 +5,7 @@ use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
 };
 use tracing::debug;
+use x509_parser::prelude::*;
 
 use crate::{
     crypto::KeyStore,
@@ -19,42 +20,63 @@ pub const DEVICE_ID_STORE: &str = "device_id";
 /// The phone checks this list before sending unsolicited data (battery, SMS messages, etc.).
 const INCOMING_CAPABILITIES: &[&str] = &[
     "kdeconnect.battery",
+    "kdeconnect.battery.request",
     "kdeconnect.clipboard",
     "kdeconnect.clipboard.connect",
     "kdeconnect.connectivity_report",
+    "kdeconnect.digitizer",
+    "kdeconnect.digitizer.session",
     "kdeconnect.contacts.response_uids_timestamps",
     "kdeconnect.contacts.response_vcards",
+    "kdeconnect.findmyphone.request",
+    "kdeconnect.mousepad.echo",
     "kdeconnect.mousepad.keyboardstate",
+    "kdeconnect.mousepad.request",
     "kdeconnect.mpris",
     "kdeconnect.mpris.request",
     "kdeconnect.notification",
+    "kdeconnect.notification.request",
     "kdeconnect.ping",
+    "kdeconnect.presenter",
+    "kdeconnect.runcommand",
     "kdeconnect.runcommand.request",
     "kdeconnect.share.request",
+    "kdeconnect.sftp",
     "kdeconnect.sms.messages",
     "kdeconnect.sms.attachment_file",
+    "kdeconnect.systemvolume.request",
     "kdeconnect.telephony",
 ];
 
 const OUTGOING_CAPABILITIES: &[&str] = &[
+    "kdeconnect.battery",
     "kdeconnect.battery.request",
     "kdeconnect.clipboard",
+    "kdeconnect.clipboard.connect",
     "kdeconnect.contacts.request_all_uids_timestamps",
     "kdeconnect.contacts.request_vcards_by_uid",
+    "kdeconnect.connectivity_report.request",
     "kdeconnect.findmyphone.request",
+    "kdeconnect.mousepad.echo",
     "kdeconnect.mousepad.keyboardstate",
     "kdeconnect.mousepad.request",
     "kdeconnect.mpris",
     "kdeconnect.mpris.request",
     "kdeconnect.notification.request",
+    "kdeconnect.notification",
+    "kdeconnect.notification.action",
+    "kdeconnect.notification.reply",
     "kdeconnect.ping",
     "kdeconnect.runcommand",
+    "kdeconnect.runcommand.request",
     "kdeconnect.share.request",
-    "kdeconnect.share.request.update",
+    "kdeconnect.sftp.request",
     "kdeconnect.sms.request",
     "kdeconnect.sms.request_conversations",
     "kdeconnect.sms.request_conversation",
     "kdeconnect.sms.request_attachment",
+    "kdeconnect.systemvolume",
+    "kdeconnect.telephony.request_mute",
 ];
 
 #[derive(Debug)]
@@ -69,42 +91,40 @@ pub struct Config {
 impl Config {
     pub async fn load(_out_caps: Vec<String>) -> anyhow::Result<Self> {
         let config_dir = dirs::config_dir()
-            .expect("cannot find config dir")
+            .ok_or_else(|| anyhow::anyhow!("cannot find config dir"))?
             .join(CONFIG_DIR);
 
         if !config_dir.exists() {
-            fs::create_dir_all(&config_dir)
-                .await
-                .expect("cannot create config dir");
+            fs::create_dir_all(&config_dir).await?;
         }
 
         let id_file = config_dir.join(DEVICE_ID_STORE);
-
-        let identity = match id_file.exists() {
-            true => {
-                let mut buffer = String::new();
-                let mut file = fs::File::open(&id_file).await.expect("cannot open file");
-
-                file.read_to_string(&mut buffer)
-                    .await
-                    .expect("fail reading file content");
-
-                let device_id = buffer.trim().to_string();
-                make_identity(device_id, Some(DEFAULT_LISTEN_PORT)).await
-            }
-            false => {
-                let device_id = uuid::Uuid::new_v4().to_string();
-
-                let mut file = fs::File::create(&id_file)
-                    .await
-                    .expect("cannot create file");
-                file.write_all(device_id.as_bytes())
-                    .await
-                    .expect("fail writing device id to file");
-
-                make_identity(device_id, Some(DEFAULT_LISTEN_PORT)).await
-            }
+        let stored_device_id = if id_file.exists() {
+            let mut buffer = String::new();
+            let mut file = fs::File::open(&id_file).await?;
+            file.read_to_string(&mut buffer).await?;
+            Some(buffer.trim().to_string())
+        } else {
+            None
         };
+
+        let cert_device_id = certificate_common_name(&config_dir.join("certificate.pem")).await;
+        let device_id = cert_device_id
+            .or(stored_device_id)
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+        if fs::read_to_string(&id_file)
+            .await
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            != Some(device_id.as_str())
+        {
+            let mut file = fs::File::create(&id_file).await?;
+            file.write_all(device_id.as_bytes()).await?;
+        }
+
+        let identity = make_identity(device_id, Some(DEFAULT_LISTEN_PORT)).await;
 
         debug!("CONFIG initialized.");
 
@@ -115,12 +135,22 @@ impl Config {
                 .to_string(),
             listen_addr: DEFAULT_LISTEN_ADDR,
             discovery_interval: DEFAULT_DISCOVERY_INTERVAL,
-            key_store: KeyStore::load(&identity.device_id)
-                .await
-                .expect("failed to create keystore"),
+            key_store: KeyStore::load(&identity.device_id).await?,
             identity,
         })
     }
+}
+
+async fn certificate_common_name(path: &std::path::Path) -> Option<String> {
+    let bytes = fs::read(path).await.ok()?;
+    let (_, pem) = parse_x509_pem(&bytes).ok()?;
+    let cert = pem.parse_x509().ok()?;
+    cert.subject()
+        .iter_common_name()
+        .next()
+        .and_then(|cn| cn.as_str().ok())
+        .map(str::to_string)
+        .filter(|id| !id.is_empty())
 }
 
 async fn make_identity(device_id: String, tcp_port: Option<u16>) -> Identity {
@@ -141,6 +171,8 @@ async fn make_identity(device_id: String, tcp_port: Option<u16>) -> Identity {
             .collect(),
         protocol_version: PROTOCOL_VERSION,
         tcp_port,
+        target_device_id: None,
+        target_protocol_version: None,
     }
 }
 
@@ -162,5 +194,28 @@ async fn identify_device_type() -> DeviceType {
         }
     } else {
         DeviceType::Desktop
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{INCOMING_CAPABILITIES, OUTGOING_CAPABILITIES};
+
+    #[test]
+    fn advertised_capabilities_cover_gsconnect_compatible_actions() {
+        assert!(OUTGOING_CAPABILITIES.contains(&"kdeconnect.clipboard.connect"));
+        assert!(OUTGOING_CAPABILITIES.contains(&"kdeconnect.notification.action"));
+        assert!(OUTGOING_CAPABILITIES.contains(&"kdeconnect.notification.reply"));
+
+        assert!(INCOMING_CAPABILITIES.contains(&"kdeconnect.clipboard.connect"));
+        assert!(INCOMING_CAPABILITIES.contains(&"kdeconnect.notification"));
+        assert!(INCOMING_CAPABILITIES.contains(&"kdeconnect.notification.request"));
+    }
+
+    #[test]
+    fn advertised_capabilities_do_not_claim_unimplemented_lock_plugin() {
+        assert!(!INCOMING_CAPABILITIES.contains(&"kdeconnect.lock"));
+        assert!(!OUTGOING_CAPABILITIES.contains(&"kdeconnect.lock"));
+        assert!(!OUTGOING_CAPABILITIES.contains(&"kdeconnect.lock.request"));
     }
 }

--- a/kdeconnect-core/src/core/connection.rs
+++ b/kdeconnect-core/src/core/connection.rs
@@ -1,0 +1,144 @@
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tokio::sync::{Mutex, mpsc, watch};
+
+use crate::{
+    device::{DeviceId, PairState},
+    protocol::{PacketType, Pair, ProtocolPacket},
+};
+
+/// Maximum allowed difference between device clocks for pairing (30 minutes in seconds).
+pub(crate) const ALLOWED_TIMESTAMP_DIFF_SECS: u64 = 1800;
+
+/// Auto-reject incoming/outgoing pairing requests after this duration (30 seconds).
+pub(crate) const PAIRING_TIMEOUT_SECS: u64 = 30;
+pub(crate) const UNPAIRED_RESYNC_INTERVAL: Duration = Duration::from_secs(2);
+pub(crate) const UNPAIRED_RESYNC_DROP_DELAY: Duration = Duration::from_millis(250);
+
+#[derive(Clone)]
+pub(crate) struct ConnectionHandle {
+    pub(crate) write_tx: mpsc::UnboundedSender<ProtocolPacket>,
+    pub(crate) shutdown_tx: watch::Sender<bool>,
+}
+
+pub(crate) async fn install_connection(
+    writer_map: &Arc<Mutex<HashMap<DeviceId, ConnectionHandle>>>,
+    conn_id_map: &Arc<Mutex<HashMap<DeviceId, u64>>>,
+    device_id: DeviceId,
+    conn_id: u64,
+    handle: ConnectionHandle,
+) {
+    let previous_handle = {
+        let mut writers = writer_map.lock().await;
+        let mut conn_ids = conn_id_map.lock().await;
+        conn_ids.insert(device_id.clone(), conn_id);
+        writers.insert(device_id, handle)
+    };
+    if let Some(previous_handle) = previous_handle {
+        let _ = previous_handle.shutdown_tx.send(true);
+    }
+}
+
+pub(crate) async fn remove_connection(
+    writer_map: &Arc<Mutex<HashMap<DeviceId, ConnectionHandle>>>,
+    conn_id_map: &Arc<Mutex<HashMap<DeviceId, u64>>>,
+    device_id: &DeviceId,
+) -> bool {
+    let removed = {
+        let mut writers = writer_map.lock().await;
+        let mut conn_ids = conn_id_map.lock().await;
+        conn_ids.remove(device_id);
+        writers.remove(device_id)
+    };
+    if let Some(handle) = removed {
+        let _ = handle.shutdown_tx.send(true);
+        true
+    } else {
+        false
+    }
+}
+
+pub(crate) async fn is_current_connection(
+    conn_id_map: &Arc<Mutex<HashMap<DeviceId, u64>>>,
+    device_id: &DeviceId,
+    conn_id: u64,
+) -> bool {
+    let guard = conn_id_map.lock().await;
+    guard
+        .get(device_id)
+        .map(|&current| current == conn_id)
+        .unwrap_or(false)
+}
+
+pub(crate) async fn remove_connection_if_current(
+    writer_map: &Arc<Mutex<HashMap<DeviceId, ConnectionHandle>>>,
+    conn_id_map: &Arc<Mutex<HashMap<DeviceId, u64>>>,
+    device_id: &DeviceId,
+    conn_id: u64,
+) -> bool {
+    let removed = {
+        let mut writers = writer_map.lock().await;
+        let mut conn_ids = conn_id_map.lock().await;
+        if conn_ids.get(device_id).copied() != Some(conn_id) {
+            return false;
+        }
+        conn_ids.remove(device_id);
+        writers.remove(device_id)
+    };
+    if let Some(handle) = removed {
+        let _ = handle.shutdown_tx.send(true);
+        true
+    } else {
+        false
+    }
+}
+
+pub(crate) async fn remove_pairing_attempt(
+    pairing_attempts: &Arc<Mutex<HashMap<DeviceId, u64>>>,
+    device_id: &DeviceId,
+) {
+    pairing_attempts.lock().await.remove(device_id);
+}
+
+pub(crate) fn pair_false_packet() -> ProtocolPacket {
+    let pair = Pair::reject();
+    let value = serde_json::to_value(pair).expect("fail serializing pair");
+    ProtocolPacket::new(PacketType::Pair, value)
+}
+
+pub(crate) fn packet_allowed_for_pair_state(
+    packet_type: &PacketType,
+    pair_state: Option<PairState>,
+) -> bool {
+    matches!(packet_type, PacketType::Pair | PacketType::Identity)
+        || pair_state == Some(PairState::Paired)
+}
+
+#[derive(Default)]
+pub(crate) struct UnpairedResyncLimiter {
+    last_sent: Mutex<HashMap<DeviceId, Instant>>,
+}
+
+impl UnpairedResyncLimiter {
+    pub(crate) async fn should_send(&self, device_id: &DeviceId) -> bool {
+        self.should_send_at(device_id, Instant::now()).await
+    }
+
+    pub(crate) async fn should_send_at(&self, device_id: &DeviceId, now: Instant) -> bool {
+        let mut guard = self.last_sent.lock().await;
+        if let Some(last_sent) = guard.get(device_id)
+            && now.duration_since(*last_sent) < UNPAIRED_RESYNC_INTERVAL
+        {
+            return false;
+        }
+        guard.insert(device_id.clone(), now);
+        true
+    }
+
+    pub(crate) async fn clear(&self, device_id: &DeviceId) {
+        self.last_sent.lock().await.remove(device_id);
+    }
+}

--- a/kdeconnect-core/src/core/events.rs
+++ b/kdeconnect-core/src/core/events.rs
@@ -1,0 +1,1241 @@
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+use tokio::sync::mpsc;
+use tracing::{debug, error, info, warn};
+
+use crate::{
+    KdeConnectCore, cleanup_device_data,
+    core::connection::{
+        ALLOWED_TIMESTAMP_DIFF_SECS, ConnectionHandle, PAIRING_TIMEOUT_SECS,
+        UNPAIRED_RESYNC_DROP_DELAY, install_connection, is_current_connection,
+        packet_allowed_for_pair_state, pair_false_packet, remove_connection,
+        remove_connection_if_current, remove_pairing_attempt,
+    },
+    device::{Device, DeviceId, PairState},
+    event::{AppEvent, ConnectionEvent, CoreEvent},
+    filetransfer::TransferAdapter,
+    plugin_config,
+    plugins::{self, ping::Ping, share::ShareRequest},
+    protocol::{DeviceFile, DevicePayload, PacketType, Pair, ProtocolPacket},
+    transport::TransportEvent,
+};
+
+impl KdeConnectCore {
+    pub(crate) async fn core_events(&self, event: CoreEvent) {
+        match event {
+            CoreEvent::PacketReceived { device, packet } => {
+                info!("[core] packet received from device: {}", device);
+                if let Some(device_obj) = self.device_manager.get_device(&device).await {
+                    self.plugin_registry
+                        .dispatch(
+                            device_obj,
+                            packet,
+                            self.event_tx.clone(),
+                            self.conn_tx.clone(),
+                            self.mpris_conn_tx.clone(),
+                        )
+                        .await;
+                }
+            }
+            CoreEvent::DeviceDiscovered(_device) => {
+                debug!("[core] device discovered.");
+            }
+            CoreEvent::DevicePaired((device_id, device)) => {
+                info!("[core] device paired: {}", device_id);
+                remove_pairing_attempt(&self.pairing_attempts, &device_id).await;
+                self.unpaired_resync_limiter.clear(&device_id).await;
+
+                if self
+                    .plugin_registry
+                    .is_plugin_enabled(&device_id.0, "contacts")
+                    .await
+                {
+                    let contacts_pkt = ProtocolPacket::new(
+                        PacketType::ContactsRequestAllUidsTimestamps,
+                        serde_json::json!({}),
+                    );
+                    let _ = self.queue_packet(&device_id, contacts_pkt).await;
+                }
+
+                if self
+                    .plugin_registry
+                    .is_plugin_enabled(&device_id.0, "sms")
+                    .await
+                {
+                    let sms_pkt = ProtocolPacket::new(
+                        PacketType::SmsRequestConversations,
+                        serde_json::json!({}),
+                    );
+                    let _ = self.queue_packet(&device_id, sms_pkt).await;
+                }
+
+                // Bootstrap MPRIS: request the phone's player list so
+                // expose_phone_mpris can register D-Bus proxies for them.
+                if self
+                    .plugin_registry
+                    .is_plugin_enabled(&device_id.0, "mpris")
+                    .await
+                {
+                    let mpris_pkt = ProtocolPacket::new(
+                        PacketType::MprisRequest,
+                        serde_json::to_value(crate::plugins::mpris::MprisRequest {
+                            request_player_list: Some(true),
+                            ..Default::default()
+                        })
+                        .unwrap(),
+                    );
+                    let _ = self.queue_packet(&device_id, mpris_pkt).await;
+                }
+
+                let conn_event = ConnectionEvent::DevicePaired((device_id, device));
+                let _ = self.conn_tx.send(conn_event.clone());
+                let _ = self.mpris_conn_tx.send(conn_event);
+            }
+            CoreEvent::DevicePairCancelled(device_id) => {
+                info!("[core] device pair cancelled.");
+                remove_pairing_attempt(&self.pairing_attempts, &device_id).await;
+                self.unpaired_resync_limiter.clear(&device_id).await;
+                plugins::systemvolume::on_device_disconnect(&device_id);
+                let conn_event = ConnectionEvent::PairStateChanged((
+                    device_id,
+                    crate::device::PairState::NotPaired,
+                ));
+                let _ = self.conn_tx.send(conn_event.clone());
+                let _ = self.mpris_conn_tx.send(conn_event);
+            }
+            CoreEvent::DevicePairStateChanged((device_id, pair_state)) => {
+                if matches!(pair_state, PairState::NotPaired | PairState::Paired) {
+                    remove_pairing_attempt(&self.pairing_attempts, &device_id).await;
+                    self.unpaired_resync_limiter.clear(&device_id).await;
+                }
+                if pair_state == PairState::NotPaired {
+                    plugins::systemvolume::on_device_disconnect(&device_id);
+                }
+                let conn_event = ConnectionEvent::PairStateChanged((device_id, pair_state));
+                let _ = self.conn_tx.send(conn_event.clone());
+                let _ = self.mpris_conn_tx.send(conn_event);
+            }
+            CoreEvent::SendPacket { device, packet } => {
+                info!("[core] sending packet");
+                let _ = self.queue_packet(&device, packet).await;
+            }
+            CoreEvent::SendPaylod {
+                device,
+                packet,
+                payload,
+                payload_size,
+            } => {
+                info!("[core] sending packet w/ payload");
+
+                if !self
+                    .packet_allowed_to_send(&device, &packet.packet_type)
+                    .await
+                {
+                    warn!(
+                        "[core] dropping payload packet {:?} for {} because device is not paired",
+                        packet.packet_type, device
+                    );
+                    return;
+                }
+
+                let sender = {
+                    let guard = self.writer_map.lock().await;
+                    guard.get(&device).map(|handle| handle.write_tx.clone())
+                };
+
+                if let Some(sender) = sender {
+                    let transfer_adapter =
+                        TransferAdapter::new(payload, payload_size, self.conn_tx.clone());
+                    self.plugin_registry
+                        .send_payload(packet, &sender, transfer_adapter, payload_size)
+                        .await;
+                }
+            }
+            CoreEvent::Error(msg) => {
+                tracing::error!("{}", msg);
+            }
+        };
+    }
+
+    pub(crate) async fn transport_events(&self, event: TransportEvent) {
+        match event {
+            TransportEvent::NewConnection {
+                addr,
+                id,
+                name,
+                write_tx,
+                conn_id,
+            } => {
+                debug!("[core] new connection from: {}", addr);
+
+                let meta = crate::transport::take_conn_metadata(&id).unwrap_or_else(|| {
+                    crate::transport::ConnMetadata {
+                        device_type: "phone".to_string(),
+                        incoming_capabilities: vec![],
+                        outgoing_capabilities: vec![],
+                        protocol_version: 0,
+                        pairing_timestamp: 0,
+                        peer_certificate: vec![],
+                        shutdown_tx: tokio::sync::watch::channel(false).0,
+                        incoming_conn_id: 0,
+                    }
+                });
+                let device_type = meta.device_type;
+                let incoming_capabilities = meta.incoming_capabilities;
+                let outgoing_capabilities = meta.outgoing_capabilities;
+                let protocol_version = meta.protocol_version;
+                let pairing_timestamp = meta.pairing_timestamp;
+                let peer_certificate = meta.peer_certificate;
+                let shutdown_tx = meta.shutdown_tx;
+                debug!("[core] new connection from: {}", addr);
+
+                let mut device = match Device::from_discovery(
+                    id.0.clone(),
+                    name,
+                    device_type,
+                    incoming_capabilities,
+                    outgoing_capabilities,
+                    addr,
+                )
+                .await
+                {
+                    Ok(d) => d,
+                    Err(e) => {
+                        tracing::error!("Failed to create device from metadata: {}", e);
+                        return;
+                    }
+                };
+
+                if device.pair_state == crate::device::PairState::Paired
+                    && device.protocol_version > protocol_version
+                {
+                    warn!(
+                        "[core] refusing protocol downgrade for paired device {}: stored={}, incoming={}",
+                        id, device.protocol_version, protocol_version
+                    );
+                    return;
+                }
+
+                let stored_remote_certificate = device.remote_certificate.clone();
+                if device.pair_state == crate::device::PairState::Paired
+                    && !stored_remote_certificate.is_empty()
+                    && stored_remote_certificate != peer_certificate
+                {
+                    warn!(
+                        "[core] TLS certificate changed for paired device {}; unpairing",
+                        id
+                    );
+                    device.remote_certificate.clear();
+                    self.device_manager
+                        .add_or_update_device(id.clone(), device.clone())
+                        .await;
+                    self.device_manager
+                        .update_pair_state(&id, crate::device::PairState::NotPaired)
+                        .await;
+                    cleanup_device_data(&id.0).await;
+                    return;
+                }
+
+                let should_backfill_certificate = device.pair_state
+                    == crate::device::PairState::Paired
+                    && stored_remote_certificate.is_empty()
+                    && !peer_certificate.is_empty();
+
+                if !peer_certificate.is_empty() {
+                    device.remote_certificate = peer_certificate;
+                }
+
+                if should_backfill_certificate {
+                    let _ = device
+                        .update_pair_state(crate::device::PairState::Paired)
+                        .await;
+                }
+
+                self.device_manager
+                    .add_or_update_device(id.clone(), device.clone())
+                    .await;
+
+                // Store the peer's protocol version and pairing timestamp.
+                self.device_manager
+                    .set_protocol_version(&id, protocol_version)
+                    .await;
+                if pairing_timestamp > 0 {
+                    self.device_manager
+                        .set_pairing_timestamp(&id, pairing_timestamp)
+                        .await;
+                }
+
+                install_connection(
+                    &self.writer_map,
+                    &self.conn_id_map,
+                    id.clone(),
+                    conn_id,
+                    ConnectionHandle {
+                        write_tx,
+                        shutdown_tx,
+                    },
+                )
+                .await;
+                debug!("[core] installed connection for {}", id);
+
+                if device.pair_state == crate::device::PairState::Paired {
+                    if self
+                        .plugin_registry
+                        .is_plugin_enabled(&id.0, "contacts")
+                        .await
+                    {
+                        let contacts_pkt = ProtocolPacket::new(
+                            PacketType::ContactsRequestAllUidsTimestamps,
+                            serde_json::json!({}),
+                        );
+                        let _ = self.queue_packet(&id, contacts_pkt).await;
+                    }
+
+                    if self
+                        .plugin_registry
+                        .is_plugin_enabled(&id.0, "notification")
+                        .await
+                    {
+                        let notification_pkt = ProtocolPacket::new(
+                            PacketType::NotificationRequest,
+                            serde_json::json!({ "request": true }),
+                        );
+                        let _ = self.queue_packet(&id, notification_pkt).await;
+                    }
+
+                    if self.plugin_registry.is_plugin_enabled(&id.0, "sms").await {
+                        let sms_pkt = ProtocolPacket::new(
+                            PacketType::SmsRequestConversations,
+                            serde_json::json!({}),
+                        );
+                        let _ = self.queue_packet(&id, sms_pkt).await;
+                    }
+
+                    if self
+                        .plugin_registry
+                        .is_plugin_enabled(&id.0, "battery")
+                        .await
+                    {
+                        let battery_pkt = ProtocolPacket::new(
+                            PacketType::BatteryRequest,
+                            serde_json::json!({ "request": true }),
+                        );
+                        let _ = self.queue_packet(&id, battery_pkt).await;
+                        plugins::battery::send_local_state(id.clone(), self.event_tx.clone()).await;
+                    }
+
+                    if self
+                        .plugin_registry
+                        .is_plugin_enabled(&id.0, "connectivity_report")
+                        .await
+                    {
+                        let connectivity_pkt = ProtocolPacket::new(
+                            PacketType::ConnectivityReportRequest,
+                            serde_json::json!({}),
+                        );
+                        let _ = self.queue_packet(&id, connectivity_pkt).await;
+                    }
+
+                    if self
+                        .plugin_registry
+                        .is_plugin_enabled(&id.0, "mousepad")
+                        .await
+                    {
+                        let keyboard_state_pkt = ProtocolPacket::new(
+                            PacketType::MousePadKeyboardState,
+                            serde_json::json!({ "state": true }),
+                        );
+                        let _ = self.queue_packet(&id, keyboard_state_pkt).await;
+                    }
+
+                    // Send our local command list so the Android app shows
+                    // the Run Command option (requires canAddCommand: true).
+                    if self
+                        .plugin_registry
+                        .is_plugin_enabled(&id.0, "runcommand")
+                        .await
+                    {
+                        plugins::run_command::send_command_list(&id, self.event_tx.clone()).await;
+                    }
+
+                    if self
+                        .plugin_registry
+                        .is_plugin_enabled(&id.0, "systemvolume")
+                        .await
+                    {
+                        plugins::systemvolume::on_device_connect(id.clone(), self.event_tx.clone());
+                    }
+                }
+
+                let conn_event = ConnectionEvent::Connected((id.clone(), device.clone()));
+                let _ = self.conn_tx.send(conn_event.clone());
+                let _ = self.mpris_conn_tx.send(conn_event);
+            }
+            TransportEvent::IncomingPacket { addr, id, raw } => {
+                let conn_id = crate::transport::CONN_METADATA
+                    .lock()
+                    .ok()
+                    .and_then(|m| m.get(&id).map(|m| m.incoming_conn_id))
+                    .unwrap_or(0);
+                if !self.is_current_connection(&id, conn_id).await {
+                    info!(
+                        "[core] stale packet from {} (conn_id {} != current) — ignoring",
+                        id, conn_id
+                    );
+                    return;
+                }
+
+                info!("[core] incoming packet.");
+                match serde_json::from_str::<ProtocolPacket>(&raw) {
+                    Ok(pkt) => {
+                        if let PacketType::Pair = pkt.packet_type {
+                            if let Ok(pair_body) = serde_json::from_value::<Pair>(pkt.body.clone())
+                                && let Some(device) = self.device_manager.get_device(&id).await
+                            {
+                                if !pair_body.pair {
+                                    // Phone sent pair:false — either it's unpairing from us, or
+                                    // it's a fresh device announcing it doesn't know us yet.
+                                    match device.pair_state {
+                                        crate::device::PairState::Paired => {
+                                            info!(
+                                                "[core] Phone unpairing from us — cleaning up {}",
+                                                id
+                                            );
+                                            remove_pairing_attempt(&self.pairing_attempts, &id)
+                                                .await;
+                                            self.device_manager
+                                                .update_pair_state(
+                                                    &id,
+                                                    crate::device::PairState::NotPaired,
+                                                )
+                                                .await;
+                                            cleanup_device_data(&id.0).await;
+                                            self.drop_connection(&id).await;
+                                        }
+                                        crate::device::PairState::Requesting
+                                        | crate::device::PairState::Requested => {
+                                            info!(
+                                                "[core] pairing with {} was rejected/cancelled by peer",
+                                                id
+                                            );
+                                            remove_pairing_attempt(&self.pairing_attempts, &id)
+                                                .await;
+                                            self.device_manager
+                                                .update_pair_state(
+                                                    &id,
+                                                    crate::device::PairState::NotPaired,
+                                                )
+                                                .await;
+                                            let ev = ConnectionEvent::PairingTimedOut(id.clone());
+                                            let _ = self.conn_tx.send(ev.clone());
+                                            let _ = self.mpris_conn_tx.send(ev);
+                                        }
+                                        crate::device::PairState::NotPaired => {
+                                            info!(
+                                                "[core] pair:false from {} — device not paired, ignoring",
+                                                id
+                                            );
+                                        }
+                                    }
+                                } else {
+                                    let device_name = device.name.clone();
+                                    let device_id_clone = id.clone();
+                                    let is_new_request = self
+                                        .pairing
+                                        .handle_pair_request(
+                                            device.device_id,
+                                            device.name,
+                                            device.address,
+                                            pkt,
+                                        )
+                                        .await
+                                        .unwrap_or(false);
+                                    if is_new_request {
+                                        let ev = ConnectionEvent::PairingRequested((
+                                            device_id_clone,
+                                            device_name,
+                                        ));
+                                        let _ = self.conn_tx.send(ev.clone());
+                                        let _ = self.mpris_conn_tx.send(ev);
+
+                                        // 30-second auto-reject: if the user doesn't respond,
+                                        // reject the pairing so neither side waits indefinitely.
+                                        let dm = self.device_manager.clone();
+                                        let event_tx = self.event_tx.clone();
+                                        let conn_tx = self.conn_tx.clone();
+                                        let mpris_tx = self.mpris_conn_tx.clone();
+                                        let did = id.clone();
+                                        tokio::spawn(async move {
+                                            tokio::time::sleep(Duration::from_secs(
+                                                PAIRING_TIMEOUT_SECS,
+                                            ))
+                                            .await;
+                                            if let Some(dev) = dm.get_device(&did).await
+                                                && dev.pair_state
+                                                    == crate::device::PairState::Requested
+                                            {
+                                                info!(
+                                                    "[core] incoming pair request from {} timed out after {}s",
+                                                    did, PAIRING_TIMEOUT_SECS
+                                                );
+                                                let pair = Pair::reject();
+                                                let value = serde_json::to_value(pair)
+                                                    .expect("fail serializing pair");
+                                                let pkt =
+                                                    ProtocolPacket::new(PacketType::Pair, value);
+                                                let _ = event_tx.send(CoreEvent::SendPacket {
+                                                    device: did.clone(),
+                                                    packet: pkt,
+                                                });
+                                                dm.update_pair_state(
+                                                    &did,
+                                                    crate::device::PairState::NotPaired,
+                                                )
+                                                .await;
+                                                let ev = ConnectionEvent::PairingTimedOut(did);
+                                                let _ = conn_tx.send(ev.clone());
+                                                let _ = mpris_tx.send(ev);
+                                            }
+                                        });
+                                    }
+                                }
+                            }
+                        } else if matches!(pkt.packet_type, PacketType::Identity) {
+                            debug!("[core] identity packet from {}; ignoring in event loop", id);
+                        } else if self
+                            .device_manager
+                            .get_device(&id)
+                            .await
+                            .map(|device| device.pair_state == crate::device::PairState::Paired)
+                            .unwrap_or(false)
+                        {
+                            let _ = self.event_tx.send(CoreEvent::PacketReceived {
+                                device: id.clone(),
+                                packet: pkt.clone(),
+                            });
+                        } else {
+                            self.reject_unpaired_packet(&id, pkt.packet_type).await;
+                        }
+                    }
+                    Err(e) => {
+                        let _ = self.event_tx.send(CoreEvent::Error(format!(
+                            "Invalid packet from {}: {}",
+                            addr, e
+                        )));
+                    }
+                }
+            }
+            TransportEvent::Disconnected { id, conn_id } => {
+                // Check whether this disconnect belongs to the connection that is
+                // currently live for this device. If conn_id_map holds a *different*
+                // (higher) ID, a newer connection has already taken over and this
+                // event is stale — dropping it avoids wiping the live writer entry.
+                let is_current = { is_current_connection(&self.conn_id_map, &id, conn_id).await };
+
+                if !is_current {
+                    info!(
+                        "[core] stale Disconnected for {} (conn_id {} != current) — ignoring",
+                        id, conn_id
+                    );
+                    return;
+                }
+
+                self.fail_pairing_if_pending(&id, "connection dropped")
+                    .await;
+                remove_connection_if_current(&self.writer_map, &self.conn_id_map, &id, conn_id)
+                    .await;
+                {
+                    let _ = crate::transport::CONN_METADATA
+                        .lock()
+                        .map(|mut m| m.remove(&id));
+                }
+                plugins::systemvolume::on_device_disconnect(&id);
+                self.broadcast_on_disconnect(&id).await;
+                info!("[core] removed dead connection for {}", id);
+                let conn_event = ConnectionEvent::Disconnected(id);
+                let _ = self.conn_tx.send(conn_event.clone());
+                let _ = self.mpris_conn_tx.send(conn_event);
+            }
+            TransportEvent::PacketSendFailed {
+                id,
+                packet_type,
+                conn_id,
+            } => {
+                if !self.is_current_connection(&id, conn_id).await {
+                    info!(
+                        "[core] stale send failure for {} (conn_id {} != current) — ignoring",
+                        id, conn_id
+                    );
+                    return;
+                }
+                warn!(
+                    "[core] failed to send {:?} to {}; removing broken connection",
+                    packet_type, id
+                );
+                if matches!(packet_type, PacketType::Pair) {
+                    self.fail_pairing_if_pending(&id, "pair packet send failed")
+                        .await;
+                }
+                if remove_connection_if_current(&self.writer_map, &self.conn_id_map, &id, conn_id)
+                    .await
+                {
+                    plugins::systemvolume::on_device_disconnect(&id);
+                    self.broadcast_on_disconnect(&id).await;
+                    let conn_event = ConnectionEvent::Disconnected(id);
+                    let _ = self.conn_tx.send(conn_event.clone());
+                    let _ = self.mpris_conn_tx.send(conn_event);
+                }
+            }
+            TransportEvent::PairTrustFailed { id } => {
+                warn!(
+                    "[core] certificate trust failed for paired device {}; unpairing",
+                    id
+                );
+                if let Some(mut device) = self.device_manager.get_device(&id).await {
+                    device.remote_certificate.clear();
+                    self.device_manager
+                        .add_or_update_device(id.clone(), device)
+                        .await;
+                }
+                self.device_manager
+                    .update_pair_state(&id, crate::device::PairState::NotPaired)
+                    .await;
+                cleanup_device_data(&id.0).await;
+            }
+        }
+    }
+
+    pub(crate) async fn kde_events(&self, event: AppEvent) {
+        match event {
+            AppEvent::Broadcasting => {
+                let _ = self.udp_transport.send_identity().await;
+            }
+            AppEvent::Pair(device_id) => {
+                info!("frontend sent pair event to device: {}", device_id);
+
+                let current_state = match self.device_manager.get_device(&device_id).await {
+                    Some(device) => device.pair_state,
+                    None => {
+                        warn!("[core] cannot pair unknown device {}", device_id);
+                        let _ = self.udp_transport.send_identity().await;
+                        let ev = ConnectionEvent::PairingTimedOut(device_id);
+                        let _ = self.conn_tx.send(ev.clone());
+                        let _ = self.mpris_conn_tx.send(ev);
+                        return;
+                    }
+                };
+
+                match current_state {
+                    crate::device::PairState::Paired => {
+                        warn!(
+                            "[core] ignoring pair request for already paired device {}",
+                            device_id
+                        );
+                        let conn_event = ConnectionEvent::PairStateChanged((
+                            device_id,
+                            crate::device::PairState::Paired,
+                        ));
+                        let _ = self.conn_tx.send(conn_event.clone());
+                        let _ = self.mpris_conn_tx.send(conn_event);
+                        return;
+                    }
+                    crate::device::PairState::Requested => {
+                        info!(
+                            "[core] pair requested while peer request is pending; accepting {}",
+                            device_id
+                        );
+                        let pair = Pair::accept();
+                        let value = serde_json::to_value(pair).expect("fail serializing pair");
+                        let pkt = ProtocolPacket::new(PacketType::Pair, value);
+                        if self.queue_packet(&device_id, pkt).await {
+                            self.device_manager.set_paired(&device_id, true).await;
+                        } else {
+                            warn!(
+                                "[core] failed to accept pending pair request from {}",
+                                device_id
+                            );
+                            self.device_manager
+                                .update_pair_state(&device_id, crate::device::PairState::NotPaired)
+                                .await;
+                            let ev = ConnectionEvent::PairingTimedOut(device_id);
+                            let _ = self.conn_tx.send(ev.clone());
+                            let _ = self.mpris_conn_tx.send(ev);
+                        }
+                        return;
+                    }
+                    crate::device::PairState::Requesting => {
+                        warn!(
+                            "[core] restarting stale or in-progress pair request for {}",
+                            device_id
+                        );
+                    }
+                    crate::device::PairState::NotPaired => {}
+                }
+
+                let pair = Pair::request();
+                if let Some(timestamp) = pair.timestamp {
+                    self.device_manager
+                        .set_pairing_timestamp(&device_id, timestamp)
+                        .await;
+                }
+                let value = serde_json::to_value(pair).expect("fail serializing pair");
+                let pkt = ProtocolPacket::new(PacketType::Pair, value);
+
+                let udp = self.udp_transport.clone();
+                let wm = self.writer_map.clone();
+                let dm = self.device_manager.clone();
+                let event_tx2 = self.event_tx.clone();
+                let conn_tx2 = self.conn_tx.clone();
+                let mpris_tx2 = self.mpris_conn_tx.clone();
+                let did = device_id.clone();
+                let pkt_clone = pkt.clone();
+
+                let queued = self.queue_packet(&device_id, pkt).await;
+                if queued {
+                    info!("Sent pair request packet to device: {}", device_id);
+                } else {
+                    warn!(
+                        "[core] failed to send pair request to {} (no active connection); reconnecting before retry",
+                        device_id
+                    );
+                    let _ = self.udp_transport.send_identity().await;
+                }
+
+                let attempt_id = {
+                    let mut attempts = self.pairing_attempts.lock().await;
+                    let next = attempts
+                        .get(&device_id)
+                        .copied()
+                        .unwrap_or(0)
+                        .wrapping_add(1);
+                    attempts.insert(device_id.clone(), next);
+                    next
+                };
+
+                self.device_manager
+                    .update_pair_state(&device_id, crate::device::PairState::Requesting)
+                    .await;
+
+                let attempts = self.pairing_attempts.clone();
+                let initially_queued = queued;
+                tokio::spawn(async move {
+                    let mut retried = false;
+
+                    if initially_queued {
+                        tokio::time::sleep(Duration::from_secs(PAIRING_TIMEOUT_SECS)).await;
+
+                        if attempts.lock().await.get(&did).copied() != Some(attempt_id) {
+                            return;
+                        }
+
+                        if let Some(dev) = dm.get_device(&did).await
+                            && dev.pair_state != crate::device::PairState::Requesting
+                        {
+                            attempts.lock().await.remove(&did);
+                            return;
+                        }
+
+                        info!(
+                            "[core] pair request to {} timed out after {}s — attempting reconnect",
+                            did, PAIRING_TIMEOUT_SECS
+                        );
+
+                        let _ = udp.send_identity().await;
+                    }
+
+                    for _ in 0..30 {
+                        tokio::time::sleep(Duration::from_millis(500)).await;
+                        let sender = wm
+                            .lock()
+                            .await
+                            .get(&did)
+                            .map(|handle| handle.write_tx.clone());
+                        if let Some(sender) = sender
+                            && sender.send(pkt_clone.clone()).is_ok()
+                        {
+                            info!("[core] pair request sent to {} after reconnect", did);
+                            retried = true;
+                            break;
+                        }
+                    }
+
+                    if retried {
+                        tokio::time::sleep(Duration::from_secs(PAIRING_TIMEOUT_SECS)).await;
+                    }
+
+                    if attempts.lock().await.get(&did).copied() != Some(attempt_id) {
+                        return;
+                    }
+
+                    if let Some(dev) = dm.get_device(&did).await
+                        && dev.pair_state == crate::device::PairState::Requesting
+                    {
+                        info!("[core] pairing with {} timed out definitively", did);
+                        let pair = Pair::reject();
+                        let value = serde_json::to_value(pair).expect("fail serializing pair");
+                        let pkt = ProtocolPacket::new(PacketType::Pair, value);
+                        let _ = event_tx2.send(CoreEvent::SendPacket {
+                            device: did.clone(),
+                            packet: pkt,
+                        });
+                        dm.update_pair_state(&did, crate::device::PairState::NotPaired)
+                            .await;
+                        attempts.lock().await.remove(&did);
+                        let ev = ConnectionEvent::PairingTimedOut(did);
+                        let _ = conn_tx2.send(ev.clone());
+                        let _ = mpris_tx2.send(ev);
+                    }
+                });
+            }
+            AppEvent::Ping((device_id, msg)) => {
+                info!("frontend sent ping event to device: {}", device_id);
+                let value = serde_json::to_value(Ping {
+                    message: Some(msg),
+                    ..Default::default()
+                })
+                .expect("fail serializing packet body");
+                let pkt = ProtocolPacket::new(PacketType::Ping, value);
+                let _ = self.queue_packet(&device_id, pkt).await;
+            }
+            AppEvent::SendPacket(device_id, packet) => {
+                let ptype = packet.packet_type.clone();
+                info!("Sending packet {:?} to device: {}", ptype, device_id);
+                if !self.queue_packet(&device_id, packet).await {
+                    warn!(
+                        "[core] failed to send {:?} to {} (not paired or no connection)",
+                        ptype, device_id
+                    );
+                }
+            }
+            AppEvent::SendFiles((device_id, files_list)) => {
+                info!("frontend trying to sent files to device: {}", device_id);
+
+                if !self
+                    .packet_allowed_to_send(&device_id, &PacketType::ShareRequest)
+                    .await
+                {
+                    warn!(
+                        "[core] dropping file send for {} because device is not paired",
+                        device_id
+                    );
+                    return;
+                }
+
+                let sender = {
+                    let guard = self.writer_map.lock().await;
+                    guard.get(&device_id).map(|handle| handle.write_tx.clone())
+                };
+
+                if let Some(sender) = sender {
+                    debug!("sender available.");
+                    let pkts = match ShareRequest::share_files(files_list).await {
+                        Ok(pkts) => pkts,
+                        Err(e) => {
+                            tracing::warn!("[share] failed to prepare share request: {}", e);
+                            return;
+                        }
+                    };
+                    for (pkt_body, path) in pkts {
+                        let packet = ProtocolPacket::new(
+                            PacketType::ShareRequest,
+                            serde_json::to_value(pkt_body).expect("serializing packet body"),
+                        );
+                        let file = match DeviceFile::open(&path).await {
+                            Ok(file) => file,
+                            Err(e) => {
+                                tracing::warn!("[share] failed to open '{}': {}", path, e);
+                                continue;
+                            }
+                        };
+                        let payload = DevicePayload::from(file);
+
+                        let transfer_adapter =
+                            TransferAdapter::new(payload.buf, payload.size, self.conn_tx.clone());
+
+                        self.plugin_registry
+                            .send_payload(packet, &sender, transfer_adapter, payload.size)
+                            .await;
+                    }
+
+                    debug!("file transfer tasks spawned.");
+                }
+            }
+            AppEvent::MprisAction((device_id, player_name, action)) => {
+                info!(
+                    "frontend sent mpris action to device: {} player: {}",
+                    device_id, player_name
+                );
+                let request = crate::plugins::mpris::MprisRequest {
+                    player: Some(player_name),
+                    request_now_playing: None,
+                    request_player_list: None,
+                    request_volume: None,
+                    seek: None,
+                    set_loop_status: None,
+                    set_position: None,
+                    set_shuffle: None,
+                    set_volume: None,
+                    action: Some(action),
+                    album_art_url: None,
+                };
+                let value = serde_json::to_value(request).expect("fail serializing packet body");
+                let pkt = ProtocolPacket::new(PacketType::MprisRequest, value);
+                if let Some(device) = self.device_manager.get_device(&device_id).await {
+                    self.plugin_registry
+                        .send(device.clone(), pkt, self.event_tx.clone())
+                        .await;
+                };
+            }
+            AppEvent::SendMprisRequest((device_id, request)) => {
+                info!("frontend sent mpris request to device: {}", device_id);
+                let value = serde_json::to_value(request).expect("fail serializing packet body");
+                let pkt = ProtocolPacket::new(PacketType::MprisRequest, value);
+                if let Some(device) = self.device_manager.get_device(&device_id).await {
+                    self.plugin_registry
+                        .send(device.clone(), pkt, self.event_tx.clone())
+                        .await;
+                };
+            }
+            AppEvent::Unpair(device_id) => {
+                info!("frontend sent unpair event to device: {}", device_id);
+
+                remove_pairing_attempt(&self.pairing_attempts, &device_id).await;
+                self.device_manager
+                    .update_pair_state(&device_id, crate::device::PairState::NotPaired)
+                    .await;
+
+                let pkt = pair_false_packet();
+                let queued = self.queue_packet(&device_id, pkt).await;
+
+                let writer_map = self.writer_map.clone();
+                let conn_id_map = self.conn_id_map.clone();
+                tokio::spawn(async move {
+                    if queued {
+                        info!("[core] sent pair:false to {} on unpair", device_id);
+                        tokio::time::sleep(Duration::from_millis(250)).await;
+                    }
+                    cleanup_device_data(&device_id.0).await;
+                    if remove_connection(&writer_map, &conn_id_map, &device_id).await {
+                        plugins::systemvolume::on_device_disconnect(&device_id);
+                        info!("[core] dropped connection for {}", device_id);
+                    }
+                });
+            }
+            AppEvent::AcceptPairing(device_id) => {
+                info!("User accepted pairing from {}", device_id);
+
+                let Some(dev) = self.device_manager.get_device(&device_id).await else {
+                    warn!("[core] ignoring accept for unknown device {}", device_id);
+                    let ev = ConnectionEvent::PairingTimedOut(device_id);
+                    let _ = self.conn_tx.send(ev.clone());
+                    let _ = self.mpris_conn_tx.send(ev);
+                    return;
+                };
+
+                if dev.pair_state != crate::device::PairState::Requested {
+                    warn!(
+                        "[core] ignoring stale pair accept for {} in state {:?}",
+                        device_id, dev.pair_state
+                    );
+                    let ev = ConnectionEvent::PairingTimedOut(device_id);
+                    let _ = self.conn_tx.send(ev.clone());
+                    let _ = self.mpris_conn_tx.send(ev);
+                    return;
+                }
+
+                // Clock-sync validation per KDE Connect protocol v8+:
+                // if the phone's pairing timestamp and our current time differ
+                // by more than 30 minutes, reject the pairing to prevent
+                // security issues from clock skew.
+                if dev.protocol_version >= 8 {
+                    let phone_ts = dev.pairing_timestamp;
+                    if phone_ts > 0 {
+                        let now = SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_secs();
+                        let diff = phone_ts.abs_diff(now);
+                        if diff > ALLOWED_TIMESTAMP_DIFF_SECS {
+                            warn!(
+                                "[core] pairing rejected for {}: clocks out of sync (phone_ts={}, local_ts={}, diff={}s)",
+                                device_id, phone_ts, now, diff
+                            );
+                            // Reject by sending pair:false and un-setting paired state.
+                            let pair = Pair::reject();
+                            let value = serde_json::to_value(pair).expect("fail serializing pair");
+                            let pkt = ProtocolPacket::new(PacketType::Pair, value);
+                            if self.queue_packet(&device_id, pkt).await {
+                                info!(
+                                    "[core] sent pair:false to {} due to clock mismatch",
+                                    device_id
+                                );
+                            }
+                            self.device_manager
+                                .update_pair_state(&device_id, crate::device::PairState::NotPaired)
+                                .await;
+                            // Emit a timed-out event so the UI can show a message.
+                            let ev = ConnectionEvent::PairingTimedOut(device_id);
+                            let _ = self.conn_tx.send(ev.clone());
+                            let _ = self.mpris_conn_tx.send(ev);
+                            return;
+                        }
+                    }
+                }
+
+                let pair = Pair::accept();
+                let value = serde_json::to_value(pair).expect("fail serializing pair");
+                let pkt = ProtocolPacket::new(PacketType::Pair, value);
+                if self.queue_packet(&device_id, pkt).await {
+                    info!("[core] sent pair:true to {} on accept", device_id);
+                    self.device_manager.set_paired(&device_id, true).await;
+                } else {
+                    warn!(
+                        "[core] failed to send pair acceptance to {} (no connection)",
+                        device_id
+                    );
+                    self.device_manager
+                        .update_pair_state(&device_id, crate::device::PairState::NotPaired)
+                        .await;
+                    let ev = ConnectionEvent::PairingTimedOut(device_id);
+                    let _ = self.conn_tx.send(ev.clone());
+                    let _ = self.mpris_conn_tx.send(ev);
+                }
+            }
+            AppEvent::RejectPairing(device_id) => {
+                info!("User rejected pairing from {}", device_id);
+
+                let Some(dev) = self.device_manager.get_device(&device_id).await else {
+                    warn!("[core] ignoring reject for unknown device {}", device_id);
+                    let ev = ConnectionEvent::PairingTimedOut(device_id);
+                    let _ = self.conn_tx.send(ev.clone());
+                    let _ = self.mpris_conn_tx.send(ev);
+                    return;
+                };
+
+                if dev.pair_state != crate::device::PairState::Requested {
+                    warn!(
+                        "[core] ignoring stale pair reject for {} in state {:?}",
+                        device_id, dev.pair_state
+                    );
+                    let ev = ConnectionEvent::PairingTimedOut(device_id);
+                    let _ = self.conn_tx.send(ev.clone());
+                    let _ = self.mpris_conn_tx.send(ev);
+                    return;
+                }
+
+                let pair = Pair::reject();
+                let value = serde_json::to_value(pair).expect("fail serializing pair");
+                let pkt = ProtocolPacket::new(PacketType::Pair, value);
+                if self.queue_packet(&device_id, pkt).await {
+                    info!("[core] sent pair:false to {} on reject", device_id);
+                }
+                self.device_manager
+                    .update_pair_state(&device_id, crate::device::PairState::NotPaired)
+                    .await;
+            }
+            AppEvent::Disconnect(device_id) => {
+                info!("frontend sent disconnect event to device: {}", device_id);
+                if self.drop_connection(&device_id).await {
+                    let conn_event = ConnectionEvent::Disconnected(device_id);
+                    let _ = self.conn_tx.send(conn_event.clone());
+                    let _ = self.mpris_conn_tx.send(conn_event);
+                    info!("Connection closed.");
+                }
+            }
+            AppEvent::SetPluginEnabled {
+                device_id,
+                plugin_id,
+                enabled,
+            } => {
+                info!(
+                    "[plugin] {} plugin '{}' for device {}",
+                    if enabled { "enabling" } else { "disabling" },
+                    plugin_id,
+                    device_id
+                );
+                let mut disabled: std::collections::HashSet<String> =
+                    plugin_config::load_disabled_plugins(&device_id.0).await;
+                if enabled {
+                    disabled.remove(&plugin_id);
+                } else {
+                    disabled.insert(plugin_id.clone());
+                }
+                plugin_config::save_disabled_plugins(&device_id.0, &disabled).await;
+                self.plugin_registry
+                    .set_device_disabled(&device_id.0, disabled.clone())
+                    .await;
+
+                if self.drop_connection(&device_id).await {
+                    info!(
+                        "[plugin] dropped connection to {} — phone will reconnect with updated capabilities",
+                        device_id
+                    );
+                }
+            }
+        };
+    }
+
+    async fn packet_allowed_to_send(&self, device_id: &DeviceId, packet_type: &PacketType) -> bool {
+        let pair_state = self
+            .device_manager
+            .get_device(device_id)
+            .await
+            .map(|device| device.pair_state);
+
+        packet_allowed_for_pair_state(packet_type, pair_state)
+    }
+
+    fn schedule_connection_drop(&self, device_id: DeviceId, delay: Duration) {
+        let writer_map = self.writer_map.clone();
+        let conn_id_map = self.conn_id_map.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(delay).await;
+            remove_connection(&writer_map, &conn_id_map, &device_id).await;
+        });
+    }
+
+    async fn reject_unpaired_packet(&self, device_id: &DeviceId, packet_type: PacketType) {
+        warn!(
+            "[core] received {:?} from unpaired device {}; rejecting stale traffic and dropping connection",
+            packet_type, device_id
+        );
+
+        remove_pairing_attempt(&self.pairing_attempts, device_id).await;
+        if self
+            .device_manager
+            .get_device(device_id)
+            .await
+            .map(|device| device.pair_state != PairState::NotPaired)
+            .unwrap_or(false)
+        {
+            self.device_manager
+                .update_pair_state(device_id, PairState::NotPaired)
+                .await;
+        }
+        plugins::systemvolume::on_device_disconnect(device_id);
+
+        if self.unpaired_resync_limiter.should_send(device_id).await {
+            if self.queue_packet(device_id, pair_false_packet()).await {
+                info!(
+                    "[core] sent pair:false to {} after unpaired {:?}",
+                    device_id, packet_type
+                );
+                self.schedule_connection_drop(device_id.clone(), UNPAIRED_RESYNC_DROP_DELAY);
+                return;
+            }
+        } else {
+            debug!(
+                "[core] throttled duplicate pair:false resync for {} after {:?}",
+                device_id, packet_type
+            );
+        }
+
+        self.drop_connection(device_id).await;
+    }
+
+    async fn queue_packet(&self, device_id: &DeviceId, packet: ProtocolPacket) -> bool {
+        if !self
+            .packet_allowed_to_send(device_id, &packet.packet_type)
+            .await
+        {
+            warn!(
+                "[core] dropping outbound {:?} for {} because device is not paired",
+                packet.packet_type, device_id
+            );
+            return false;
+        }
+
+        let sender = {
+            let guard = self.writer_map.lock().await;
+            let sender = guard.get(device_id).map(|handle| handle.write_tx.clone());
+            if sender.is_none() {
+                debug!(
+                    "No sender for device {} — available: {:?}",
+                    device_id,
+                    guard.keys().collect::<Vec<_>>()
+                );
+            }
+            sender
+        };
+
+        let Some(sender) = sender else {
+            return false;
+        };
+
+        if let Err(e) = sender.send(packet) {
+            tracing::warn!(
+                "[core] failed to queue packet for {}: {}; removing stale writer",
+                device_id,
+                e
+            );
+            remove_connection(&self.writer_map, &self.conn_id_map, device_id).await;
+            plugins::systemvolume::on_device_disconnect(device_id);
+            self.broadcast_on_disconnect(device_id).await;
+            let conn_event = ConnectionEvent::Disconnected(device_id.clone());
+            let _ = self.conn_tx.send(conn_event.clone());
+            let _ = self.mpris_conn_tx.send(conn_event);
+            return false;
+        }
+
+        true
+    }
+
+    async fn broadcast_on_disconnect(&self, device_id: &DeviceId) {
+        if let Some(device) = self.device_manager.get_device(device_id).await {
+            if device.pair_state == PairState::Paired {
+                debug!(
+                    "[core] broadcasting identity after disconnect of {}",
+                    device_id
+                );
+                if let Err(e) = self.udp_transport.send_identity().await {
+                    error!("Identity broadcast after disconnect failed: {}", e);
+                }
+            }
+        }
+    }
+
+    async fn drop_connection(&self, device_id: &DeviceId) -> bool {
+        if remove_connection(&self.writer_map, &self.conn_id_map, device_id).await {
+            plugins::systemvolume::on_device_disconnect(device_id);
+            info!("[core] dropped connection for {}", device_id);
+            true
+        } else {
+            false
+        }
+    }
+
+    async fn is_current_connection(&self, device_id: &DeviceId, conn_id: u64) -> bool {
+        is_current_connection(&self.conn_id_map, device_id, conn_id).await
+    }
+
+    async fn fail_pairing_if_pending(&self, device_id: &DeviceId, reason: &str) {
+        let Some(device) = self.device_manager.get_device(device_id).await else {
+            return;
+        };
+
+        if !matches!(
+            device.pair_state,
+            PairState::Requesting | PairState::Requested
+        ) {
+            return;
+        }
+
+        warn!(
+            "[core] pairing with {} failed while in {:?}: {}",
+            device_id, device.pair_state, reason
+        );
+        remove_pairing_attempt(&self.pairing_attempts, device_id).await;
+        self.device_manager
+            .update_pair_state(device_id, PairState::NotPaired)
+            .await;
+        let ev = ConnectionEvent::PairingTimedOut(device_id.clone());
+        let _ = self.conn_tx.send(ev.clone());
+        let _ = self.mpris_conn_tx.send(ev);
+    }
+
+    pub fn take_events(&self) -> Arc<mpsc::UnboundedSender<AppEvent>> {
+        self.out_tx.clone()
+    }
+}

--- a/kdeconnect-core/src/crypto.rs
+++ b/kdeconnect-core/src/crypto.rs
@@ -24,19 +24,32 @@ pub struct KeyStore {
 impl KeyStore {
     pub async fn load(device_uuid: &str) -> anyhow::Result<Self> {
         let config_dir = dirs::config_dir()
-            .expect("cant find config directory")
+            .ok_or_else(|| anyhow::anyhow!("cannot find config directory"))?
             .join(CONFIG_DIR);
 
         if !config_dir.exists() {
-            fs::create_dir_all(&config_dir)
-                .await
-                .expect("failed to create config directory");
+            fs::create_dir_all(&config_dir).await?;
         }
 
-        let cert_path = config_dir.join(format!("device_cert@{}.pem", device_uuid));
-        let keys_path = config_dir.join(format!("device_key@{}.pem", device_uuid));
+        let standard_cert_path = config_dir.join("certificate.pem");
+        let kde_standard_keys_path = config_dir.join("privateKey.pem");
+        let gsconnect_standard_keys_path = config_dir.join("private.pem");
+        let device_cert_path = config_dir.join(format!("device_cert@{}.pem", device_uuid));
+        let device_keys_path = config_dir.join(format!("device_key@{}.pem", device_uuid));
 
-        if !keys_path.exists() && !cert_path.exists() {
+        // Prefer the standard KDE Connect/GSConnect filenames when present.
+        // This preserves existing pairings when migrating from another desktop
+        // implementation; Android pins the desktop certificate for a device ID.
+        let (cert_path, keys_path) =
+            if standard_cert_path.exists() && kde_standard_keys_path.exists() {
+                (standard_cert_path, kde_standard_keys_path)
+            } else if standard_cert_path.exists() && gsconnect_standard_keys_path.exists() {
+                (standard_cert_path, gsconnect_standard_keys_path)
+            } else {
+                (device_cert_path, device_keys_path)
+            };
+
+        if !keys_path.exists() || !cert_path.exists() {
             let key = KeyPair::generate()?.serialize_pem();
             let mut key_file = fs::File::create(&keys_path).await?;
             key_file.write_all(key.as_bytes()).await?;
@@ -48,16 +61,11 @@ impl KeyStore {
 
         let verifier = Arc::new(NoCertificateVerification::new(default_provider()));
 
-        // Read files asynchronously
-        let cert_bytes = fs::read(&cert_path)
-            .await
-            .expect("reading certificate file");
-        let keys_bytes = fs::read(&keys_path)
-            .await
-            .expect("reading private key file");
+        let cert_bytes = fs::read(&cert_path).await?;
+        let keys_bytes = fs::read(&keys_path).await?;
 
-        let cert = CertificateDer::from_pem_slice(&cert_bytes).expect("decoding certfificate");
-        let keys = PrivateKeyDer::from_pem_slice(&keys_bytes).expect("decoding private key");
+        let cert = CertificateDer::from_pem_slice(&cert_bytes)?;
+        let keys = PrivateKeyDer::from_pem_slice(&keys_bytes)?;
 
         let client_config = Arc::new(
             rustls::ClientConfig::builder()
@@ -69,8 +77,7 @@ impl KeyStore {
         let server_config = Arc::new(
             rustls::ServerConfig::builder()
                 .with_client_cert_verifier(verifier.clone())
-                .with_single_cert(vec![cert], keys)
-                .expect("building server config"),
+                .with_single_cert(vec![cert], keys)?,
         );
 
         Ok(Self {

--- a/kdeconnect-core/src/device.rs
+++ b/kdeconnect-core/src/device.rs
@@ -29,7 +29,7 @@ impl Display for DeviceId {
 
 #[derive(Debug, Clone)]
 pub enum DeviceState {
-    Battery { level: u8, charging: bool },
+    Battery { level: i32, charging: bool },
     Connectivity((String, i32)),
 }
 
@@ -46,8 +46,32 @@ pub enum PairState {
 pub struct Device {
     pub name: String,
     pub device_id: DeviceId,
+    #[serde(default = "default_device_type")]
+    pub device_type: String,
+    #[serde(default)]
+    pub incoming_capabilities: Vec<String>,
+    #[serde(default)]
+    pub outgoing_capabilities: Vec<String>,
     pub address: SocketAddr,
     pub pair_state: PairState,
+    #[serde(default = "default_protocol_version")]
+    pub protocol_version: usize,
+    /// UNIX timestamp (seconds) from the most recent pairing handshake,
+    /// used for clock-sync validation per the KDE Connect protocol v8+.
+    #[serde(default)]
+    pub pairing_timestamp: u64,
+    /// DER-encoded TLS certificate presented by the peer when pairing.
+    /// Paired LAN devices must keep presenting this certificate on reconnect.
+    #[serde(default)]
+    pub remote_certificate: Vec<u8>,
+}
+
+fn default_protocol_version() -> usize {
+    0
+}
+
+fn default_device_type() -> String {
+    "phone".to_string()
 }
 
 impl Default for Device {
@@ -55,16 +79,37 @@ impl Default for Device {
         Self {
             name: String::new(),
             device_id: DeviceId(String::new()),
+            device_type: default_device_type(),
+            incoming_capabilities: Vec::new(),
+            outgoing_capabilities: Vec::new(),
             address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, DEFAULT_LISTEN_PORT)),
             pair_state: PairState::default(),
+            protocol_version: default_protocol_version(),
+            pairing_timestamp: 0,
+            remote_certificate: Vec::new(),
         }
     }
 }
 
 impl Device {
-    pub async fn new(id: String, name: String, address: SocketAddr) -> anyhow::Result<Self> {
-        let device_id = DeviceId(id);
-        let config_dir = dirs::config_dir().unwrap().join(CONFIG_DIR);
+    /// Legacy constructor for upstream-compatible callers.
+    pub async fn new(id: String, name: String, addr: SocketAddr) -> anyhow::Result<Self> {
+        Self::from_discovery(id, name, "phone".to_string(), vec![], vec![], addr).await
+    }
+
+    pub async fn from_discovery(
+        id: String,
+        name: String,
+        device_type: String,
+        incoming_capabilities: Vec<String>,
+        outgoing_capabilities: Vec<String>,
+        address: SocketAddr,
+    ) -> anyhow::Result<Self> {
+        let device_id = DeviceId(validate_device_id(&id)?);
+        let name = sanitize_device_name(&name);
+        let config_dir = dirs::config_dir()
+            .ok_or_else(|| anyhow::anyhow!("cannot find config dir"))?
+            .join(CONFIG_DIR);
         let file_path = config_dir.join(format!("{}.ron", &device_id));
 
         if file_path.exists() {
@@ -72,27 +117,56 @@ impl Device {
             let mut file = fs::File::open(file_path).await?;
             file.read_to_string(&mut buffer).await?;
 
-            return Ok(ron::de::from_str::<Self>(&buffer)?);
+            let mut device = ron::de::from_str::<Self>(&buffer)?;
+            if device.pair_state != PairState::Paired {
+                device.pair_state = PairState::NotPaired;
+                device.pairing_timestamp = 0;
+                device.remote_certificate.clear();
+            }
+            device.name = name;
+            device.address = address;
+            device.device_type = device_type;
+            device.incoming_capabilities = incoming_capabilities;
+            device.outgoing_capabilities = outgoing_capabilities;
+            return Ok(device);
         }
 
         Ok(Self {
             name,
             device_id,
+            device_type,
+            incoming_capabilities,
+            outgoing_capabilities,
             address,
             pair_state: PairState::NotPaired,
+            protocol_version: 0,
+            pairing_timestamp: 0,
+            remote_certificate: Vec::new(),
         })
     }
 
     pub async fn store_device_identity(&self, pair_state: PairState) -> anyhow::Result<()> {
         let mut data = self.clone();
-        data.pair_state = pair_state;
+        data.pair_state = if pair_state == PairState::Paired {
+            PairState::Paired
+        } else {
+            PairState::NotPaired
+        };
+        if data.pair_state == PairState::NotPaired {
+            data.remote_certificate.clear();
+            data.pairing_timestamp = 0;
+        }
 
         if let Ok(file_content) = ron::ser::to_string_pretty(&data, PrettyConfig::new()) {
-            let config_dir = dirs::config_dir().unwrap().join(CONFIG_DIR);
+            let config_dir = dirs::config_dir()
+                .ok_or_else(|| anyhow::anyhow!("cannot find config dir"))?
+                .join(CONFIG_DIR);
             let file_path = config_dir.join(format!("{}.ron", self.device_id));
 
-            if file_path.exists() {
-                fs::remove_file(&file_path).await?
+            if let Err(e) = fs::remove_file(&file_path).await
+                && e.kind() != std::io::ErrorKind::NotFound
+            {
+                return Err(e.into());
             }
 
             let mut file = fs::File::create(file_path).await?;
@@ -109,7 +183,7 @@ impl Device {
 #[derive(Debug, Clone)]
 pub struct DeviceManager {
     devices: Arc<RwLock<HashMap<DeviceId, Device>>>,
-    event_tx: mpsc::UnboundedSender<CoreEvent>,
+    pub(crate) event_tx: mpsc::UnboundedSender<CoreEvent>,
 }
 
 impl DeviceManager {
@@ -120,9 +194,18 @@ impl DeviceManager {
         }
     }
 
-    pub async fn add_or_update_device(&self, device_id: DeviceId, device: Device) {
+    pub async fn add_or_update_device(&self, device_id: DeviceId, mut device: Device) {
         info!("updating: {}", device_id);
         let mut guard = self.devices.write().await;
+        if let Some(existing) = guard.get(&device_id)
+            && matches!(
+                existing.pair_state,
+                PairState::Requesting | PairState::Requested
+            )
+            && device.pair_state == PairState::NotPaired
+        {
+            device.pair_state = existing.pair_state;
+        }
         guard.entry(device_id).insert_entry(device.clone());
     }
 
@@ -137,35 +220,394 @@ impl DeviceManager {
     }
 
     pub async fn set_paired(&self, id: &DeviceId, flag: bool) {
-        let mut guard = self.devices.write().await;
+        let device_clone = {
+            let mut guard = self.devices.write().await;
 
-        if let Some(device) = guard.get_mut(id) {
+            let Some(device) = guard.get_mut(id) else {
+                return;
+            };
+
             if flag {
                 device.pair_state = PairState::Paired;
                 let _ = self.event_tx.send(CoreEvent::DevicePaired((
                     device.device_id.clone(),
                     device.clone(),
                 )));
-                let _ = device.update_pair_state(PairState::Paired).await;
             } else {
                 device.pair_state = PairState::NotPaired;
+                device.remote_certificate.clear();
                 let _ = self
                     .event_tx
                     .send(CoreEvent::DevicePairCancelled(device.device_id.clone()));
-                let _ = device.update_pair_state(PairState::NotPaired).await;
             }
-        }
+            device.clone()
+        };
+
+        let state = if flag {
+            PairState::Paired
+        } else {
+            PairState::NotPaired
+        };
+        device_clone.update_pair_state(state).await;
     }
 
     pub async fn update_pair_state(&self, id: &DeviceId, state: PairState) {
-        let mut guard = self.devices.write().await;
+        let device_clone = {
+            let mut guard = self.devices.write().await;
 
-        if let Some(device) = guard.get_mut(id) {
+            let Some(device) = guard.get_mut(id) else {
+                return;
+            };
             device.pair_state = state;
+            if state == PairState::NotPaired {
+                device.remote_certificate.clear();
+            }
             let _ = self
                 .event_tx
                 .send(CoreEvent::DevicePairStateChanged((id.clone(), state)));
-            let _ = device.update_pair_state(state).await;
+            device.clone()
+        };
+
+        device_clone.update_pair_state(state).await;
+    }
+
+    pub async fn set_protocol_version(&self, id: &DeviceId, version: usize) {
+        let mut paired_device_to_store = None;
+        {
+            let mut guard = self.devices.write().await;
+            if let Some(device) = guard.get_mut(id) {
+                if device.protocol_version == version {
+                    return;
+                }
+                device.protocol_version = version;
+                if device.pair_state == PairState::Paired {
+                    paired_device_to_store = Some(device.clone());
+                }
+            }
         }
+
+        if let Some(device) = paired_device_to_store {
+            let _ = device.store_device_identity(PairState::Paired).await;
+        }
+    }
+
+    pub async fn set_pairing_timestamp(&self, id: &DeviceId, timestamp: u64) {
+        let mut guard = self.devices.write().await;
+        if let Some(device) = guard.get_mut(id) {
+            device.pairing_timestamp = timestamp;
+        }
+    }
+
+    pub async fn get_pairing_timestamp(&self, id: &DeviceId) -> u64 {
+        let guard = self.devices.read().await;
+        guard.get(id).map(|d| d.pairing_timestamp).unwrap_or(0)
+    }
+}
+
+/// Validate a device ID per the KDE Connect protocol.
+/// Must match `^[a-zA-Z0-9_-]{32,38}$` (32-38 alphanumeric chars, hyphens, underscores).
+pub fn validate_device_id(id: &str) -> anyhow::Result<String> {
+    if id.len() < 32
+        || id.len() > 38
+        || !id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err(anyhow::anyhow!(
+            "Invalid device ID '{}': must be 32-38 alphanumeric characters, underscores, or hyphens",
+            id
+        ));
+    }
+    Ok(id.to_string())
+}
+
+/// Sanitize a device name by removing forbidden characters.
+/// Valid names contain only characters that are NOT in the set: `"',;:.!?()[]<>`
+/// and must be 1-32 characters after trimming.
+pub fn sanitize_device_name(name: &str) -> String {
+    let sanitized: String = name
+        .chars()
+        .filter(|c| {
+            !matches!(
+                c,
+                '"' | '\'' | ',' | ';' | ':' | '.' | '!' | '?' | '(' | ')' | '[' | ']' | '<' | '>'
+            )
+        })
+        .collect::<String>()
+        .trim()
+        .to_string();
+
+    if sanitized.is_empty() {
+        "Unknown Device".to_string()
+    } else if sanitized.chars().count() > 32 {
+        sanitized.chars().take(32).collect()
+    } else {
+        sanitized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    async fn setup_test_env() -> (tokio::sync::MutexGuard<'static, ()>, tempfile::TempDir) {
+        let guard = crate::TEST_ENV_LOCK.lock().await;
+        let td = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("HOME", td.path());
+        }
+        tokio::fs::create_dir_all(td.path().join(".config").join(crate::config::CONFIG_DIR))
+            .await
+            .unwrap();
+        (guard, td)
+    }
+
+    #[test]
+    fn sanitizes_long_unicode_device_names_without_panicking() {
+        let name = sanitize_device_name(
+            "電話電話電話電話電話電話電話電話電話電話電話電話電話電話電話電話電話",
+        );
+
+        assert_eq!(name.chars().count(), 32);
+    }
+
+    #[test]
+    fn sanitize_removes_forbidden_characters() {
+        assert_eq!(sanitize_device_name("Phone's \"Test\""), "Phones Test");
+        assert_eq!(sanitize_device_name("Phone;Drop"), "PhoneDrop");
+        assert_eq!(sanitize_device_name("<script>"), "script");
+    }
+
+    #[test]
+    fn sanitize_empty_name_returns_unknown() {
+        assert_eq!(sanitize_device_name(""), "Unknown Device");
+        assert_eq!(sanitize_device_name("..."), "Unknown Device");
+        assert_eq!(sanitize_device_name("   "), "Unknown Device");
+    }
+
+    #[test]
+    fn validate_device_id_rejects_short_ids() {
+        assert!(validate_device_id("short").is_err());
+        assert!(validate_device_id("abc").is_err());
+    }
+
+    #[test]
+    fn validate_device_id_rejects_long_ids() {
+        let long_id = "a".repeat(39);
+        assert!(validate_device_id(&long_id).is_err());
+    }
+
+    #[test]
+    fn validate_device_id_rejects_special_chars() {
+        assert!(validate_device_id("abcdef1234567890abcdef12345678/0").is_err());
+        assert!(validate_device_id("abcdef1234567890abcdef1234567..0").is_err());
+        assert!(validate_device_id("abcdef1234567890abcdef12345678 0").is_err());
+    }
+
+    #[test]
+    fn validate_device_id_accepts_valid_ids() {
+        assert!(validate_device_id("abcdef1234567890abcdef1234567890").is_ok());
+        assert!(validate_device_id("ABCDEF-1234_5678-abcdef123456789").is_ok());
+    }
+
+    #[tokio::test]
+    async fn device_manager_add_and_get() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let dm = DeviceManager::new(tx);
+
+        let id = DeviceId("test-device-mgr-add-00000000000000".to_string());
+        let device = Device {
+            device_id: id.clone(),
+            name: "Test Phone".to_string(),
+            ..Default::default()
+        };
+
+        dm.add_or_update_device(id.clone(), device.clone()).await;
+
+        let retrieved = dm.get_device(&id).await;
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().name, "Test Phone");
+    }
+
+    #[tokio::test]
+    async fn device_manager_set_paired_emits_event() {
+        let (_guard, _td) = setup_test_env().await;
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let dm = DeviceManager::new(tx);
+
+        let id = DeviceId("test-device-pair-emit-0000000000".to_string());
+        let device = Device {
+            device_id: id.clone(),
+            ..Default::default()
+        };
+        dm.add_or_update_device(id.clone(), device).await;
+
+        dm.set_paired(&id, true).await;
+
+        let dev = dm.get_device(&id).await.unwrap();
+        assert_eq!(dev.pair_state, PairState::Paired);
+
+        let event = rx.try_recv();
+        assert!(event.is_ok());
+    }
+
+    #[tokio::test]
+    async fn device_manager_update_pair_state() {
+        let (_guard, _td) = setup_test_env().await;
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let dm = DeviceManager::new(tx);
+
+        let id = DeviceId("test-device-state-up-0000000000".to_string());
+        let device = Device {
+            device_id: id.clone(),
+            ..Default::default()
+        };
+        dm.add_or_update_device(id.clone(), device).await;
+
+        dm.update_pair_state(&id, PairState::Requesting).await;
+        assert_eq!(
+            dm.get_device(&id).await.unwrap().pair_state,
+            PairState::Requesting
+        );
+
+        dm.update_pair_state(&id, PairState::Paired).await;
+        assert_eq!(
+            dm.get_device(&id).await.unwrap().pair_state,
+            PairState::Paired
+        );
+
+        dm.update_pair_state(&id, PairState::NotPaired).await;
+        let dev = dm.get_device(&id).await.unwrap();
+        assert_eq!(dev.pair_state, PairState::NotPaired);
+        assert!(dev.remote_certificate.is_empty());
+    }
+
+    #[tokio::test]
+    async fn device_manager_preserves_transient_pair_state_on_identity_refresh() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let dm = DeviceManager::new(tx);
+
+        let id = DeviceId("transient-refresh-device".to_string());
+        let requesting = Device {
+            device_id: id.clone(),
+            pair_state: PairState::Requesting,
+            ..Default::default()
+        };
+        dm.add_or_update_device(id.clone(), requesting).await;
+
+        let refreshed = Device {
+            device_id: id.clone(),
+            pair_state: PairState::NotPaired,
+            ..Default::default()
+        };
+        dm.add_or_update_device(id.clone(), refreshed).await;
+
+        assert_eq!(
+            dm.get_device(&id).await.unwrap().pair_state,
+            PairState::Requesting
+        );
+    }
+
+    #[tokio::test]
+    async fn transient_pair_states_are_not_persisted_or_reloaded() {
+        let (_guard, td) = setup_test_env().await;
+        let config_dir = td.path().join(".config").join(crate::config::CONFIG_DIR);
+
+        let raw_id = "transientdevice00000000000000000";
+        let device = Device {
+            name: "Test Phone".to_string(),
+            device_id: DeviceId(raw_id.to_string()),
+            pair_state: PairState::Requesting,
+            pairing_timestamp: 1234567890,
+            remote_certificate: vec![1, 2, 3],
+            ..Default::default()
+        };
+
+        device
+            .store_device_identity(PairState::Requesting)
+            .await
+            .unwrap();
+        let stored = tokio::fs::read_to_string(config_dir.join(format!("{}.ron", raw_id)))
+            .await
+            .unwrap();
+        let stored_device = ron::de::from_str::<Device>(&stored).unwrap();
+        assert_eq!(stored_device.pair_state, PairState::NotPaired);
+        assert_eq!(stored_device.pairing_timestamp, 0);
+        assert!(stored_device.remote_certificate.is_empty());
+
+        let loaded = Device::from_discovery(
+            raw_id.to_string(),
+            "Loaded Phone".to_string(),
+            "phone".to_string(),
+            vec![],
+            vec![],
+            Device::default().address,
+        )
+        .await
+        .unwrap();
+        assert_eq!(loaded.pair_state, PairState::NotPaired);
+        assert_eq!(loaded.pairing_timestamp, 0);
+        assert!(loaded.remote_certificate.is_empty());
+    }
+
+    #[tokio::test]
+    async fn device_manager_unpair_clears_certificate() {
+        let (_guard, _td) = setup_test_env().await;
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let dm = DeviceManager::new(tx);
+
+        let id = DeviceId("test-device-cert-clr-0000000000".to_string());
+        let device = Device {
+            device_id: id.clone(),
+            pair_state: PairState::Paired,
+            remote_certificate: vec![1, 2, 3, 4],
+            ..Default::default()
+        };
+        dm.add_or_update_device(id.clone(), device).await;
+
+        dm.set_paired(&id, false).await;
+
+        let dev = dm.get_device(&id).await.unwrap();
+        assert_eq!(dev.pair_state, PairState::NotPaired);
+        assert!(dev.remote_certificate.is_empty());
+    }
+
+    #[tokio::test]
+    async fn device_manager_protocol_version_and_timestamp() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let dm = DeviceManager::new(tx);
+
+        let id = DeviceId("test-device-version-0000000000000".to_string());
+        let device = Device {
+            device_id: id.clone(),
+            ..Default::default()
+        };
+        dm.add_or_update_device(id.clone(), device).await;
+
+        dm.set_protocol_version(&id, 8).await;
+        assert_eq!(dm.get_device(&id).await.unwrap().protocol_version, 8);
+
+        dm.set_pairing_timestamp(&id, 1234567890).await;
+        assert_eq!(dm.get_pairing_timestamp(&id).await, 1234567890);
+    }
+
+    #[tokio::test]
+    async fn device_manager_get_devices_returns_all() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let dm = DeviceManager::new(tx);
+
+        for i in 0..3 {
+            let id = DeviceId(format!("test-device-list-{:02}-000000000000", i));
+            let device = Device {
+                device_id: id.clone(),
+                name: format!("Phone {}", i),
+                ..Default::default()
+            };
+            dm.add_or_update_device(id, device).await;
+        }
+
+        let devices = dm.get_devices().await;
+        assert_eq!(devices.len(), 3);
     }
 }

--- a/kdeconnect-core/src/event.rs
+++ b/kdeconnect-core/src/event.rs
@@ -64,15 +64,19 @@ pub enum ConnectionEvent {
     Connected((DeviceId, Device)),
     DevicePaired((DeviceId, Device)),
     Disconnected(DeviceId),
-    StateUpdated(DeviceState),
+    StateUpdated((DeviceId, DeviceState)),
     PairStateChanged((DeviceId, PairState)),
     Mpris((DeviceId, Mpris)),
     SmsMessages(SmsMessages),
-    ContactsReceived(HashMap<String, String>),
+    ContactsReceived(DeviceId, HashMap<String, String>),
     UpdateTransferProgress(u8),
     /// Phone sent pair:true and is waiting for user decision.
     /// Payload is (device_id, device_name).
     PairingRequested((DeviceId, String)),
+    /// The 30-second pairing window expired without user action.
+    PairingTimedOut(DeviceId),
+    /// Pairing is no longer waiting for user action for this device.
+    PairingFinished(DeviceId),
     /// Phone sent its command list via kdeconnect.runcommand.
     RunCommandListReceived((DeviceId, Vec<RemoteCommand>)),
 }

--- a/kdeconnect-core/src/lib.rs
+++ b/kdeconnect-core/src/lib.rs
@@ -36,6 +36,10 @@ pub use protocol::{PacketType, ProtocolPacket};
 
 pub static GLOBAL_CONFIG: OnceLock<config::Config> = OnceLock::new();
 
+#[cfg(test)]
+pub(crate) static TEST_ENV_LOCK: once_cell::sync::Lazy<Mutex<()>> =
+    once_cell::sync::Lazy::new(|| Mutex::new(()));
+
 pub struct KdeConnectCore {
     device_manager: Arc<DeviceManager>,
     pairing: Arc<PairingManager>,

--- a/kdeconnect-core/src/lib.rs
+++ b/kdeconnect-core/src/lib.rs
@@ -16,7 +16,7 @@ use crate::{
     plugin_interface::PluginRegistry,
     plugins::{ping::Ping, share::ShareRequest},
     protocol::{DeviceFile, DevicePayload, Pair},
-    transport::{TcpTransport, TransportEvent, UdpTransport},
+    transport::{ConnectionRateLimiter, TcpTransport, TransportEvent, UdpTransport},
 };
 
 pub mod config;
@@ -83,8 +83,10 @@ impl KdeConnectCore {
         let device_manager = DeviceManager::new(event_tx.clone());
         let pairing = Arc::new(PairingManager::new(device_manager.clone()));
 
-        let tcp_transport = TcpTransport::new(&transport_tx);
-        let udp_transport = Arc::new(UdpTransport::new(&transport_tx).await);
+        let connection_rate_limiter = Arc::new(ConnectionRateLimiter::default());
+        let tcp_transport = TcpTransport::new(&transport_tx, connection_rate_limiter.clone());
+        let udp_transport =
+            Arc::new(UdpTransport::new(&transport_tx, connection_rate_limiter).await);
 
         tokio::spawn(async move {
             if let Err(e) = tcp_transport.listen().await {
@@ -430,6 +432,10 @@ impl KdeConnectCore {
                 let conn_event = ConnectionEvent::Disconnected(id);
                 let _ = self.conn_tx.send(conn_event.clone());
                 let _ = self.mpris_conn_tx.send(conn_event);
+            }
+            TransportEvent::PairTrustFailed { id, .. }
+            | TransportEvent::PacketSendFailed { id, .. } => {
+                debug!("[core] transport reported connection failure for {}", id);
             }
         }
     }

--- a/kdeconnect-core/src/lib.rs
+++ b/kdeconnect-core/src/lib.rs
@@ -106,6 +106,7 @@ impl KdeConnectCore {
         let sms_plugin = plugins::sms::SmsMessages {
             messages: Vec::new(),
             version: None,
+            device_id: None,
         };
         plugin_registry.register(Arc::new(sms_plugin)).await;
 

--- a/kdeconnect-core/src/plugin_config.rs
+++ b/kdeconnect-core/src/plugin_config.rs
@@ -9,10 +9,14 @@ use tokio::fs;
 use crate::config::CONFIG_DIR;
 
 fn config_path(device_id: &str) -> std::path::PathBuf {
+    let safe_id: String = device_id
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+        .collect();
     dirs::config_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
         .join(CONFIG_DIR)
-        .join(format!("{}_plugins.json", device_id))
+        .join(format!("{}_plugins.json", safe_id))
 }
 
 /// Load the set of disabled plugin IDs for a device.
@@ -21,15 +25,7 @@ pub async fn load_disabled_plugins(device_id: &str) -> HashSet<String> {
     let path = config_path(device_id);
     match fs::read_to_string(&path).await {
         Ok(json) => serde_json::from_str::<HashSet<String>>(&json).unwrap_or_default(),
-        Err(_) => {
-            // No config yet — seed with plugins disabled by default.
-            // Remote Input and Presentation Mode require compositor RDP support
-            // which COSMIC does not yet provide.
-            let mut defaults = HashSet::new();
-            defaults.insert("mousepad".to_string());
-            defaults.insert("presenter".to_string());
-            defaults
-        }
+        Err(_) => HashSet::new(),
     }
 }
 
@@ -46,5 +42,63 @@ pub async fn save_disabled_plugins(device_id: &str, disabled: &HashSet<String>) 
             }
         }
         Err(e) => tracing::warn!("[plugin_config] serialize failed: {}", e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_path_sanitizes_traversal_attempts() {
+        let path = config_path("../../../etc/passwd");
+        let filename = path.file_name().unwrap().to_str().unwrap();
+        assert_eq!(filename, "etcpasswd_plugins.json");
+        assert!(!path.to_str().unwrap().contains(".."));
+    }
+
+    #[test]
+    fn config_path_preserves_valid_device_ids() {
+        let path = config_path("abcdef1234567890abcdef1234567890");
+        let filename = path.file_name().unwrap().to_str().unwrap();
+        assert_eq!(filename, "abcdef1234567890abcdef1234567890_plugins.json");
+    }
+
+    #[test]
+    fn config_path_handles_hyphens_and_underscores() {
+        let path = config_path("abc-def_123-456-789012345678901234");
+        let filename = path.file_name().unwrap().to_str().unwrap();
+        assert_eq!(filename, "abc-def_123-456-789012345678901234_plugins.json");
+    }
+
+    #[tokio::test]
+    async fn load_returns_empty_set_for_missing_file() {
+        let _guard = crate::TEST_ENV_LOCK.lock().await;
+        let _td = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("HOME", _td.path());
+        }
+        let result = load_disabled_plugins("nonexistent_device_id_000000000000").await;
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn save_and_load_round_trips() {
+        let _guard = crate::TEST_ENV_LOCK.lock().await;
+        let td = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("HOME", td.path());
+        }
+        let config_dir = td.path().join(".config").join("kdeconnect");
+        tokio::fs::create_dir_all(&config_dir).await.unwrap();
+
+        let device_id = "test_device_roundtrip_000000000000";
+        let mut disabled = HashSet::new();
+        disabled.insert("battery".to_string());
+        disabled.insert("clipboard".to_string());
+
+        save_disabled_plugins(device_id, &disabled).await;
+        let loaded = load_disabled_plugins(device_id).await;
+        assert_eq!(loaded, disabled);
     }
 }

--- a/kdeconnect-core/src/plugin_interface.rs
+++ b/kdeconnect-core/src/plugin_interface.rs
@@ -1,27 +1,20 @@
 use std::{
     collections::{HashMap, HashSet},
+    future::Future,
+    pin::Pin,
     sync::Arc,
 };
 use tokio::{
     io::{AsyncRead, AsyncWriteExt},
     sync::{RwLock, mpsc},
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     GLOBAL_CONFIG,
     device::Device,
     event::{ConnectionEvent, CoreEvent},
-    filetransfer::{send_progress, TransferAdapter},
-    plugins::{
-        self,
-        battery::Battery,
-        clipboard::Clipboard,
-        connectivity_report::ConnectivityReport,
-        mpris::{Mpris, MprisRequest},
-        systemvolume::SystemVolumeRequest,
-        telephony::TelephonyPacket,
-    },
+    filetransfer::{TransferAdapter, send_progress},
     protocol::{PacketPayloadTransferInfo, PacketType, ProtocolPacket},
     transport::prepare_listener_for_payload,
 };
@@ -39,6 +32,7 @@ fn packet_plugin_id(pt: &PacketType) -> Option<&'static str> {
         PacketType::ConnectivityReport | PacketType::ConnectivityReportRequest => {
             Some("connectivity_report")
         }
+        PacketType::Digitizer | PacketType::DigitizerSession => Some("digitizer"),
         PacketType::ContactsResponseUidsTimestamps
         | PacketType::ContactsResponseVcards
         | PacketType::ContactsRequestAllUidsTimestamps
@@ -52,6 +46,7 @@ fn packet_plugin_id(pt: &PacketType) -> Option<&'static str> {
         PacketType::Ping => Some("ping"),
         PacketType::RunCommand | PacketType::RunCommandRequest => Some("runcommand"),
         PacketType::ShareRequest | PacketType::ShareRequestUpdate => Some("share"),
+        PacketType::Sftp | PacketType::SftpRequest => Some("sftp"),
         PacketType::SmsMessages
         | PacketType::SmsRequest
         | PacketType::SmsRequestConversations
@@ -59,25 +54,34 @@ fn packet_plugin_id(pt: &PacketType) -> Option<&'static str> {
         | PacketType::SmsAttachmentFile
         | PacketType::SmsRequestAttachment => Some("sms"),
         PacketType::SystemVolume | PacketType::SystemVolumeRequest => Some("systemvolume"),
-        PacketType::Telephony | PacketType::TelephonyRequestMute => Some("telephony"),
-        // Core / unmanaged packets are never gated
-        PacketType::Identity
-        | PacketType::Pair
-        | PacketType::Lock
-        | PacketType::LockRequest
-        | PacketType::MousePadEcho
+        PacketType::MousePadEcho
         | PacketType::MousePadKeyboardState
-        | PacketType::MousePadRequest
-        | PacketType::Presenter
-        | PacketType::Sftp
-        | PacketType::SftpRequest
-        | PacketType::Unknown(_) => None,
+        | PacketType::MousePadRequest => Some("mousepad"),
+        PacketType::Presenter => Some("presenter"),
+        PacketType::Telephony | PacketType::TelephonyRequestMute => Some("telephony"),
+        PacketType::Lock | PacketType::LockRequest => Some("lock"),
+        // Core / unmanaged packets are never gated
+        PacketType::Identity | PacketType::Pair | PacketType::Unknown(_) => None,
     }
 }
+
+/// A type-erased packet handler stored in the registry.
+type HandlerFn = dyn Fn(
+        Device,
+        serde_json::Value,
+        mpsc::UnboundedSender<CoreEvent>,
+        mpsc::UnboundedSender<ConnectionEvent>,
+        mpsc::UnboundedSender<ConnectionEvent>,
+        Option<PacketPayloadTransferInfo>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send>>
+    + Send
+    + Sync;
 
 #[derive(Clone)]
 pub struct PluginRegistry {
     plugins: Arc<RwLock<Vec<Arc<dyn Plugin>>>>,
+    /// PacketType → handler function (registered at startup).
+    handlers: Arc<RwLock<HashMap<PacketType, Arc<HandlerFn>>>>,
     /// device_id.0 → set of disabled plugin IDs
     disabled: Arc<RwLock<HashMap<String, HashSet<String>>>>,
 }
@@ -86,6 +90,7 @@ impl PluginRegistry {
     pub fn new() -> Self {
         Self {
             plugins: Arc::new(RwLock::new(Vec::new())),
+            handlers: Arc::new(RwLock::new(HashMap::new())),
             disabled: Arc::new(RwLock::new(HashMap::new())),
         }
     }
@@ -94,6 +99,11 @@ impl PluginRegistry {
         let mut plugins = self.plugins.write().await;
         info!("Registering plugin: {}", plugin.id());
         plugins.push(plugin);
+    }
+
+    /// Register a handler for a specific PacketType.
+    pub async fn register_handler(&self, packet_type: PacketType, handler: Arc<HandlerFn>) {
+        self.handlers.write().await.insert(packet_type, handler);
     }
 
     /// Replace the disabled set for a device (called on connect and on toggle).
@@ -122,222 +132,37 @@ impl PluginRegistry {
         mpris_tx: mpsc::UnboundedSender<ConnectionEvent>,
     ) {
         // Gate on plugin enabled state before doing any work.
-        if let Some(plugin_id) = packet_plugin_id(&packet.packet_type) {
-            if !self
-                .is_plugin_enabled(&device.device_id.0, plugin_id)
-                .await
-            {
-                debug!(
-                    "[plugin_registry] packet {:?} skipped — plugin '{}' disabled for {}",
-                    packet.packet_type, plugin_id, device.device_id
-                );
-                return;
-            }
+        if let Some(plugin_id) = packet_plugin_id(&packet.packet_type)
+            && !self.is_plugin_enabled(&device.device_id.0, plugin_id).await
+        {
+            debug!(
+                "[plugin_registry] packet {:?} skipped — plugin '{}' disabled for {}",
+                packet.packet_type, plugin_id, device.device_id
+            );
+            return;
         }
 
-        let body = packet.body.clone();
         info!("[dispatch] packet type: {:?}", packet.packet_type);
-        let core_tx = core_tx.clone();
-        let connection_tx = tx.clone();
-        let mpris_connection_tx = mpris_tx.clone();
-        let payload_info = packet.payload_transfer_info;
 
-        match packet.packet_type {
-            PacketType::Identity => {
-                debug!("Skipping identity packet");
-            }
-            PacketType::Pair => {
-                debug!("Skipping pair packet");
-            }
-            PacketType::Battery => {
-                if let Ok(battery) = serde_json::from_value::<Battery>(body) {
-                    battery.received_packet(connection_tx).await;
-                }
-            }
-            PacketType::BatteryRequest => {
-                debug!("BatteryRequest received — not implemented, ignoring");
-            }
-            PacketType::SmsMessages => {
-                debug!("Received SmsMessages packet");
-                if let Ok(sms_messages) =
-                    serde_json::from_value::<plugins::sms::SmsMessages>(body.clone())
-                {
-                    info!(
-                        "Received SMS messages packet with {} messages",
-                        sms_messages.messages.len()
-                    );
-                    debug!(
-                        "Successfully parsed {} SMS messages",
-                        sms_messages.messages.len()
-                    );
-                    sms_messages.received_packet(connection_tx).await;
-                } else {
-                    warn!("Failed to parse SMS messages packet: {:?}", body);
-                }
-            }
-            PacketType::ContactsResponseUidsTimestamps => {
-                debug!("Received ContactsResponseUidsTimestamps");
-                if let Some(uids_val) = body.get("uids").and_then(|v| v.as_array()) {
-                    let uids: Vec<String> = uids_val
-                        .iter()
-                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                        .collect();
-                    if !uids.is_empty() {
-                        debug!("Requesting vcards for {} UIDs", uids.len());
-                        let packet = ProtocolPacket::new(
-                            PacketType::ContactsRequestVcardsByUid,
-                            serde_json::json!({ "uids": uids }),
-                        );
-                        let _ = core_tx.send(CoreEvent::SendPacket {
-                            device: device.device_id.clone(),
-                            packet,
-                        });
-                    }
-                }
-            }
-            PacketType::ContactsResponseVcards => {
-                debug!("Received ContactsResponseVcards");
-                let mut contacts: std::collections::HashMap<String, String> =
-                    std::collections::HashMap::new();
-                if let Some(uids_val) = body.get("uids").and_then(|v| v.as_array()) {
-                    for uid_val in uids_val {
-                        if let Some(uid) = uid_val.as_str() {
-                            if let Some(vcard_str) = body.get(uid).and_then(|v| v.as_str()) {
-                                let (name_opt, phones) = parse_vcard(vcard_str);
-                                if let Some(name) = name_opt {
-                                    for phone in phones {
-                                        contacts.insert(phone, name.clone());
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                debug!("Parsed {} phone->name contact entries", contacts.len());
-                if !contacts.is_empty() {
-                    let _ = connection_tx.send(ConnectionEvent::ContactsReceived(contacts));
-                }
-            }
-            PacketType::Clipboard => {
-                if let Ok(clipboard) = serde_json::from_value::<Clipboard>(body) {
-                    clipboard.received_packet(connection_tx).await;
-                }
-            }
-            PacketType::ConnectivityReport => {
-                if let Ok(connectivity_rep) = serde_json::from_value::<ConnectivityReport>(body) {
-                    connectivity_rep.received_packet(connection_tx).await;
-                }
-            }
-            PacketType::ClipboardConnect => {
-                if let Ok(clipboard) = serde_json::from_value::<Clipboard>(body)
-                    && let Some(timestamp) = clipboard.timestamp
-                {
-                    let local_ts = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_millis() as u64)
-                        .unwrap_or(0);
-                    if timestamp > 0 && timestamp >= local_ts {
-                        info!("Clipboard sync on connect accepted (ts={} local={})", timestamp, local_ts);
-                        clipboard.received_packet(connection_tx).await;
-                    } else {
-                        info!("Clipboard sync on connect ignored — stale timestamp (ts={} local={})", timestamp, local_ts);
-                    }
-                }
-            }
-            PacketType::MousePadKeyboardState => {
-                if let Ok(keyboard_state) =
-                    serde_json::from_value::<plugins::mousepad::KeyboardState>(body)
-                {
-                    debug!("{:?}", keyboard_state);
-                }
-            }
-            PacketType::Mpris => {
-                if let Ok(mpris_packet) = serde_json::from_value::<Mpris>(body) {
-                    info!("Received MPRIS packet: {:?}", mpris_packet);
-                    let mpris_event =
-                        ConnectionEvent::Mpris((device.device_id.clone(), mpris_packet));
-                    let _ = connection_tx.send(mpris_event.clone());
-                    let _ = mpris_connection_tx.send(mpris_event);
-                }
-            }
-            PacketType::MprisRequest => {
-                if let Ok(mpris_request) = serde_json::from_value::<MprisRequest>(body) {
-                    mpris_request.received_packet(&device, core_tx).await;
-                }
-            }
-            PacketType::Notification => {
-                debug!("Received notification packet");
-                info!("Notification body: {:?}", body);
-                if let Ok(notification) =
-                    serde_json::from_value::<plugins::notification::Notification>(body)
-                {
-                    notification.received_packet(&device, core_tx).await;
-                }
-            }
-            PacketType::Ping => {
-                if let Ok(ping) = serde_json::from_value::<plugins::ping::Ping>(body) {
-                    ping.received_packet(&device, core_tx).await;
-                }
-            }
-            PacketType::RunCommand => {
-                if let Ok(run_command) =
-                    serde_json::from_value::<plugins::run_command::RunCommand>(body)
-                {
-                    run_command
-                        .received_packet(&device, connection_tx, core_tx)
-                        .await;
-                }
-            }
-            PacketType::RunCommandRequest => {
-                if let Ok(run_command_request) =
-                    serde_json::from_value::<plugins::run_command::RunCommandRequest>(body)
-                {
-                    run_command_request
-                        .received_packet(&device, connection_tx, core_tx)
-                        .await;
-                }
-            }
-            PacketType::ShareRequest => {
-                if let Ok(share_request) =
-                    serde_json::from_value::<plugins::share::ShareRequest>(body)
-                    && let Some(payload_info) = payload_info
-                {
-                    // Spawn so the event loop is not blocked during the
-                    // notification dialog wait + network payload download.
-                    tokio::spawn(async move {
-                        if let Err(e) = share_request.receive_share(&device, &payload_info).await {
-                            warn!("[share] receive_share failed: {}", e);
-                        }
-                    });
-                }
-            }
-            PacketType::SystemVolumeRequest => {
-                if let Ok(req) = serde_json::from_value::<SystemVolumeRequest>(body) {
-                    req.handle(&device, core_tx).await;
-                }
-            }
-            PacketType::Telephony => {
-                if let Ok(pkt) = serde_json::from_value::<TelephonyPacket>(body) {
-                    pkt.received_packet(&device, core_tx).await;
-                }
-            }
-            PacketType::TelephonyRequestMute => {
-                debug!("TelephonyRequestMute received — no action needed on desktop");
-            }
-            _ => {
-                debug!(
-                    "No plugin found to handle packet type: {:?}",
-                    packet.packet_type
-                );
-            }
+        if let Some(handler) = self.handlers.read().await.get(&packet.packet_type).cloned() {
+            handler(
+                device,
+                packet.body.clone(),
+                core_tx,
+                tx,
+                mpris_tx,
+                packet.payload_transfer_info,
+            )
+            .await;
+        } else {
+            debug!(
+                "No handler registered for packet type: {:?}",
+                packet.packet_type
+            );
         }
     }
 
     /// Send a packet that carries a binary payload (file / album art).
-    ///
-    /// The packet is enqueued immediately so the phone knows which port to
-    /// connect to. The actual TLS accept + byte copy is spawned as a
-    /// background task so the event loop is never blocked.
     pub async fn send_payload(
         &self,
         packet: ProtocolPacket,
@@ -367,12 +192,9 @@ impl PluginRegistry {
         let payload_transfer_info = Some(PacketPayloadTransferInfo { port: addr.port() });
         let body = packet.body.clone();
 
-        // Enqueue the packet with the port info NOW — the phone needs this to
-        // know where to connect. This is non-blocking (channel send).
         match packet.packet_type {
             PacketType::Mpris => {
-                if let Ok(mpris) = serde_json::from_value::<plugins::mpris::Mpris>(body) {
-                    debug!("got mpris packet, sending info.");
+                if let Ok(mpris) = serde_json::from_value::<crate::plugins::mpris::Mpris>(body) {
                     let _ = mpris
                         .send_art(device_writer, payload_size, payload_transfer_info)
                         .await;
@@ -380,25 +202,22 @@ impl PluginRegistry {
             }
             PacketType::ShareRequest => {
                 if let Ok(share_request) =
-                    serde_json::from_value::<plugins::share::ShareRequest>(body)
+                    serde_json::from_value::<crate::plugins::share::ShareRequest>(body)
                 {
-                    debug!("got share request packet, sending info.");
                     let _ = share_request
                         .send_file(device_writer, payload_size, payload_transfer_info)
                         .await;
                 }
             }
             _ => {
-                warn!(
-                    "[payload] No plugin found to handle packet type: {:?}",
+                error!(
+                    "[payload] unsupported payload type: {:?}; payload dropped",
                     packet.packet_type
                 );
                 return;
             }
         }
 
-        // Spawn the accept + copy so the event loop stays responsive for the
-        // entire duration of the file transfer.
         let server_config = GLOBAL_CONFIG.get().unwrap().key_store.server_config.clone();
         tokio::spawn(async move {
             let (incoming, peer_addr) = match free_listener.accept().await {
@@ -422,11 +241,15 @@ impl PluginRegistry {
             };
 
             debug!("[payload] TLS accepted, copying payload");
-            let _ = tokio::io::copy(&mut payload, &mut stream).await;
-            let _ = stream.flush().await;
+            if let Err(e) = tokio::io::copy(&mut payload, &mut stream).await {
+                warn!("[payload] copy failed: {}", e);
+                return;
+            }
+            if let Err(e) = stream.flush().await {
+                warn!("[payload] flush failed: {}", e);
+                return;
+            }
             let _ = stream.shutdown().await;
-            // Guarantee a final 100% progress event so the UI always clears
-            // regardless of file size or interval timing.
             send_progress(100, payload.notify_tx.clone());
             info!("[payload] successfully sent payload to {}", peer_addr);
         });
@@ -443,12 +266,14 @@ impl PluginRegistry {
 
         match packet.packet_type {
             PacketType::Ping => {
-                if let Ok(ping) = serde_json::from_value::<plugins::ping::Ping>(body) {
+                if let Ok(ping) = serde_json::from_value::<crate::plugins::ping::Ping>(body) {
                     ping.send_packet(&device, core_event).await;
                 }
             }
             PacketType::MprisRequest => {
-                if let Ok(mpris_request) = serde_json::from_value::<MprisRequest>(body) {
+                if let Ok(mpris_request) =
+                    serde_json::from_value::<crate::plugins::mpris::MprisRequest>(body)
+                {
                     mpris_request.send_packet(&device, core_event).await;
                 }
             }
@@ -465,32 +290,4 @@ impl PluginRegistry {
         let plugins = self.plugins.read().await;
         plugins.iter().map(|p| p.id().to_string()).collect()
     }
-}
-
-fn parse_vcard(content: &str) -> (Option<String>, Vec<String>) {
-    let mut name: Option<String> = None;
-    let mut phones: Vec<String> = Vec::new();
-    for line in content.lines() {
-        let line = line.trim();
-        if line.starts_with("FN:") {
-            name = Some(line[3..].trim().to_string());
-        } else if name.is_none() && line.starts_with("N:") {
-            let parts: Vec<&str> = line[2..].split(';').collect();
-            if parts.len() >= 2 {
-                let full = format!("{} {}", parts[1].trim(), parts[0].trim());
-                let full = full.trim().to_string();
-                if !full.is_empty() {
-                    name = Some(full);
-                }
-            }
-        } else if line.starts_with("TEL") {
-            if let Some(pos) = line.rfind(':') {
-                let phone = line[pos + 1..].trim().to_string();
-                if !phone.is_empty() {
-                    phones.push(phone);
-                }
-            }
-        }
-    }
-    (name, phones)
 }

--- a/kdeconnect-core/src/plugins/battery.rs
+++ b/kdeconnect-core/src/plugins/battery.rs
@@ -1,7 +1,14 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use tokio::sync::mpsc;
+use std::path::PathBuf;
+use tokio::{fs, sync::mpsc};
+use tracing::debug;
 
-use crate::{device::DeviceState, event::ConnectionEvent, plugin_interface::Plugin};
+use crate::{
+    device::{DeviceId, DeviceState},
+    event::{ConnectionEvent, CoreEvent},
+    plugin_interface::Plugin,
+    protocol::{PacketType, ProtocolPacket},
+};
 
 fn serialize_threshold<S>(x: &bool, s: S) -> Result<S::Ok, S::Error>
 where
@@ -14,26 +21,24 @@ fn deserialize_threshold<'de, D>(deserializer: D) -> Result<bool, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let buf = i32::deserialize(deserializer)?;
-
-    match buf {
-        0 => Ok(false),
-        1 => Ok(true),
-        _ => Err(serde::de::Error::invalid_value(
-            serde::de::Unexpected::Signed(buf.into()),
-            &"0 or 1",
-        )),
+    use serde_json::Value;
+    let v = Value::deserialize(deserializer)?;
+    match v {
+        Value::Bool(b) => Ok(b),
+        Value::Number(n) => Ok(n.as_i64().unwrap_or(0) != 0),
+        _ => Ok(false),
     }
 }
 
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct Battery {
     #[serde(rename = "currentCharge")]
-    pub charge: u8,
+    pub charge: i32,
     #[serde(rename = "isCharging")]
     pub is_charging: bool,
     #[serde(
         rename = "thresholdEvent",
+        default,
         serialize_with = "serialize_threshold",
         deserialize_with = "deserialize_threshold"
     )]
@@ -47,12 +52,147 @@ impl Plugin for Battery {
 }
 
 impl Battery {
-    pub async fn received_packet(&self, event: mpsc::UnboundedSender<ConnectionEvent>) {
-        event
-            .send(ConnectionEvent::StateUpdated(DeviceState::Battery {
+    pub async fn received_packet(
+        &self,
+        device_id: DeviceId,
+        event: mpsc::UnboundedSender<ConnectionEvent>,
+    ) {
+        let _ = event.send(ConnectionEvent::StateUpdated((
+            device_id,
+            DeviceState::Battery {
                 level: self.charge,
                 charging: self.is_charging,
-            }))
-            .unwrap();
+            },
+        )));
+    }
+}
+
+pub async fn send_local_state(device: DeviceId, event: mpsc::UnboundedSender<CoreEvent>) {
+    let battery = read_local_battery().await.unwrap_or_else(no_local_battery);
+
+    let packet = ProtocolPacket::new(
+        PacketType::Battery,
+        serde_json::to_value(battery).unwrap_or_default(),
+    );
+    let _ = event.send(CoreEvent::SendPacket { device, packet });
+}
+
+fn no_local_battery() -> Battery {
+    Battery {
+        charge: -1,
+        is_charging: false,
+        under_threshold: false,
+    }
+}
+
+async fn read_local_battery() -> Option<Battery> {
+    let mut entries = fs::read_dir("/sys/class/power_supply").await.ok()?;
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let path = entry.path();
+        let kind = read_trimmed(path.join("type")).await.unwrap_or_default();
+        if kind != "Battery" {
+            continue;
+        }
+
+        let charge = read_trimmed(path.join("capacity"))
+            .await
+            .and_then(|value| value.parse::<i32>().ok())
+            .unwrap_or(100);
+        let status = read_trimmed(path.join("status")).await.unwrap_or_default();
+        let is_charging = matches!(status.as_str(), "Charging" | "Full");
+
+        return Some(Battery {
+            charge,
+            is_charging,
+            under_threshold: charge <= 15,
+        });
+    }
+
+    debug!("[battery] no local battery found; reporting no-battery sentinel");
+    None
+}
+
+async fn read_trimmed(path: PathBuf) -> Option<String> {
+    fs::read_to_string(path)
+        .await
+        .ok()
+        .map(|value| value.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Battery, no_local_battery};
+
+    #[test]
+    fn accepts_protocol_no_battery_sentinel() {
+        let battery: Battery = serde_json::from_value(serde_json::json!({
+            "currentCharge": -1,
+            "isCharging": false,
+            "thresholdEvent": 0
+        }))
+        .unwrap();
+
+        assert_eq!(battery.charge, -1);
+        assert!(!battery.is_charging);
+    }
+
+    #[test]
+    fn defaults_missing_threshold_event_to_false() {
+        let battery: Battery = serde_json::from_value(serde_json::json!({
+            "currentCharge": 87,
+            "isCharging": true
+        }))
+        .unwrap();
+
+        assert_eq!(battery.charge, 87);
+        assert!(battery.is_charging);
+        assert!(!battery.under_threshold);
+    }
+
+    #[test]
+    fn accepts_boolean_threshold_event() {
+        let battery: Battery = serde_json::from_value(serde_json::json!({
+            "currentCharge": 10,
+            "isCharging": false,
+            "thresholdEvent": true
+        }))
+        .unwrap();
+        assert!(battery.under_threshold);
+
+        let battery: Battery = serde_json::from_value(serde_json::json!({
+            "currentCharge": 80,
+            "isCharging": true,
+            "thresholdEvent": false
+        }))
+        .unwrap();
+        assert!(!battery.under_threshold);
+    }
+
+    #[test]
+    fn accepts_integer_threshold_event() {
+        let battery: Battery = serde_json::from_value(serde_json::json!({
+            "currentCharge": 10,
+            "isCharging": false,
+            "thresholdEvent": 1
+        }))
+        .unwrap();
+        assert!(battery.under_threshold);
+
+        let battery: Battery = serde_json::from_value(serde_json::json!({
+            "currentCharge": 80,
+            "isCharging": true,
+            "thresholdEvent": 0
+        }))
+        .unwrap();
+        assert!(!battery.under_threshold);
+    }
+
+    #[test]
+    fn no_local_battery_uses_protocol_sentinel() {
+        let battery = no_local_battery();
+
+        assert_eq!(battery.charge, -1);
+        assert!(!battery.is_charging);
+        assert!(!battery.under_threshold);
     }
 }

--- a/kdeconnect-core/src/plugins/connectivity_report.rs
+++ b/kdeconnect-core/src/plugins/connectivity_report.rs
@@ -1,4 +1,4 @@
-use crate::device::DeviceState;
+use crate::device::{DeviceId, DeviceState};
 use crate::event::ConnectionEvent;
 use crate::plugin_interface::Plugin;
 use serde::{Deserialize, Serialize};
@@ -69,14 +69,16 @@ impl Plugin for ConnectivityReport {
     }
 }
 impl ConnectivityReport {
-    pub async fn received_packet(&self, event: mpsc::UnboundedSender<ConnectionEvent>) {
+    pub async fn received_packet(
+        &self,
+        device_id: DeviceId,
+        event: mpsc::UnboundedSender<ConnectionEvent>,
+    ) {
         self.signal_strengths.values().for_each(|v| {
-            event
-                .send(ConnectionEvent::StateUpdated(DeviceState::Connectivity((
-                    v.network_type.to_string(),
-                    v.signal_strength,
-                ))))
-                .unwrap();
+            let _ = event.send(ConnectionEvent::StateUpdated((
+                device_id.clone(),
+                DeviceState::Connectivity((v.network_type.to_string(), v.signal_strength)),
+            )));
         });
     }
 }

--- a/kdeconnect-core/src/plugins/contacts.rs
+++ b/kdeconnect-core/src/plugins/contacts.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use tokio::sync::mpsc;
 use tracing::info;
 
-use crate::event::ConnectionEvent;
+use crate::{device::DeviceId, event::ConnectionEvent};
 
 /// Parses a vCard string and returns (Option<name>, Vec<phone_numbers>)
 pub fn parse_vcard(content: &str) -> (Option<String>, Vec<String>) {
@@ -12,8 +12,8 @@ pub fn parse_vcard(content: &str) -> (Option<String>, Vec<String>) {
 
     for line in content.lines() {
         let line = line.trim();
-        if line.starts_with("FN:") {
-            name = Some(line[3..].trim().to_string());
+        if let Some(stripped) = line.strip_prefix("FN:") {
+            name = Some(stripped.trim().to_string());
         } else if name.is_none() && line.starts_with("N:") {
             let parts: Vec<&str> = line[2..].split(';').collect();
             if parts.len() >= 2 {
@@ -24,12 +24,12 @@ pub fn parse_vcard(content: &str) -> (Option<String>, Vec<String>) {
                     name = Some(full);
                 }
             }
-        } else if line.starts_with("TEL") {
-            if let Some(pos) = line.rfind(':') {
-                let phone = line[pos + 1..].trim().to_string();
-                if !phone.is_empty() {
-                    phones.push(phone);
-                }
+        } else if line.starts_with("TEL")
+            && let Some(pos) = line.rfind(':')
+        {
+            let phone = line[pos + 1..].trim().to_string();
+            if !phone.is_empty() {
+                phones.push(phone);
             }
         }
     }
@@ -53,7 +53,11 @@ pub fn parse_uids_timestamps(body: &Value) -> Vec<String> {
 
 /// Parses a `kdeconnect.contacts.response_vcards` packet body and emits
 /// a `ConnectionEvent::ContactsReceived` with a phone → name map.
-pub fn parse_vcards_and_emit(body: &Value, tx: &mpsc::UnboundedSender<ConnectionEvent>) {
+pub fn parse_vcards_and_emit(
+    device_id: DeviceId,
+    body: &Value,
+    tx: &mpsc::UnboundedSender<ConnectionEvent>,
+) {
     let uids: Vec<String> = match body.get("uids").and_then(|v| v.as_array()) {
         Some(arr) => arr
             .iter()
@@ -83,10 +87,49 @@ pub fn parse_vcards_and_emit(body: &Value, tx: &mpsc::UnboundedSender<Connection
         contacts.len(),
         uids.len()
     );
-    let _ = tx.send(ConnectionEvent::ContactsReceived(contacts));
+    let _ = tx.send(ConnectionEvent::ContactsReceived(device_id, contacts));
 }
 
 /// Builds the body for a `kdeconnect.contacts.request_vcards_by_uid` packet.
 pub fn build_vcards_request(uids: Vec<String>) -> Value {
     serde_json::json!({ "uids": uids })
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::mpsc;
+
+    use super::{build_vcards_request, parse_vcards_and_emit};
+    use crate::{device::DeviceId, event::ConnectionEvent};
+
+    #[test]
+    fn build_vcards_request_uses_protocol_uids_shape() {
+        assert_eq!(
+            build_vcards_request(vec!["1".to_string(), "2".to_string()]),
+            serde_json::json!({ "uids": ["1", "2"] })
+        );
+    }
+
+    #[test]
+    fn emits_contacts_with_source_device_id() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let device_id = DeviceId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string());
+        parse_vcards_and_emit(
+            device_id.clone(),
+            &serde_json::json!({
+                "uids": ["contact-1"],
+                "contact-1": "BEGIN:VCARD\nFN:Jane Doe\nTEL;TYPE=CELL:+15551234567\nEND:VCARD\n"
+            }),
+            &tx,
+        );
+
+        let event = rx.try_recv().expect("contacts event");
+        match event {
+            ConnectionEvent::ContactsReceived(id, contacts) => {
+                assert_eq!(id, device_id);
+                assert_eq!(contacts.get("+15551234567"), Some(&"Jane Doe".to_string()));
+            }
+            _ => panic!("unexpected event"),
+        }
+    }
 }

--- a/kdeconnect-core/src/plugins/mousepad.rs
+++ b/kdeconnect-core/src/plugins/mousepad.rs
@@ -1,14 +1,804 @@
 use serde::{Deserialize, Serialize};
+use std::{
+    io::Read as _,
+    process::{Command, ExitStatus, Stdio},
+    sync::{
+        Mutex as StdMutex, OnceLock,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant},
+};
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
 
-use crate::plugin_interface::Plugin;
+use crate::{
+    device::{Device, DeviceId},
+    event::CoreEvent,
+    plugin_interface::Plugin,
+    protocol::{PacketType, ProtocolPacket},
+};
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct KeyboardState {
-    state: Option<bool>,
+    pub state: Option<bool>,
 }
 
 impl Plugin for KeyboardState {
     fn id(&self) -> &'static str {
         "kdeconnect.mousepad.keyboardstate"
+    }
+}
+
+static YDOTOOL_MISSING_WARNED: AtomicBool = AtomicBool::new(false);
+static YDOTOOL_DAEMON_WARNED: AtomicBool = AtomicBool::new(false);
+static YDOTOOL_TIMEOUT_WARNED: AtomicBool = AtomicBool::new(false);
+static INPUT_QUEUE_FULL_WARNED: AtomicBool = AtomicBool::new(false);
+static INPUT_QUEUE_CLOSED_WARNED: AtomicBool = AtomicBool::new(false);
+static MOTION_FLUSH_QUEUED: AtomicBool = AtomicBool::new(false);
+
+const INPUT_QUEUE_CAPACITY: usize = 256;
+const YDOTOOL_TIMEOUT: Duration = Duration::from_secs(2);
+const MAX_MOTION_BATCHES_PER_FLUSH: usize = 8;
+
+static INPUT_QUEUE: OnceLock<mpsc::Sender<InputJob>> = OnceLock::new();
+static MOTION_ACCUMULATOR: OnceLock<StdMutex<MotionAccumulator>> = OnceLock::new();
+
+#[derive(Debug)]
+enum InputJob {
+    Mousepad {
+        request: MousepadRequest,
+        device: DeviceId,
+        core_tx: mpsc::UnboundedSender<CoreEvent>,
+    },
+    FlushMouseMotion,
+    Presenter(PresenterRequest),
+}
+
+#[derive(Debug, Default)]
+struct MotionAccumulator {
+    pointer_dx: f64,
+    pointer_dy: f64,
+    scroll_dx: f64,
+    scroll_dy: f64,
+}
+
+#[derive(Debug, Default)]
+struct MotionBatch {
+    pointer_dx: i64,
+    pointer_dy: i64,
+    scroll_dx: i64,
+    scroll_dy: i64,
+}
+
+impl MotionAccumulator {
+    fn add_request(&mut self, request: &MousepadRequest) {
+        let dx = request.dx.unwrap_or_default();
+        let dy = request.dy.unwrap_or_default();
+        if request.scroll.unwrap_or(false) {
+            self.scroll_dx += dx;
+            self.scroll_dy += dy;
+        } else {
+            self.pointer_dx += dx;
+            self.pointer_dy += dy;
+        }
+    }
+
+    fn add_presenter_request(&mut self, request: &PresenterRequest) {
+        self.pointer_dx += request.dx.unwrap_or_default() * 1000.0;
+        self.pointer_dy += request.dy.unwrap_or_default() * 1000.0;
+    }
+
+    fn has_dispatchable_motion(&self) -> bool {
+        self.pointer_dx.round() != 0.0
+            || self.pointer_dy.round() != 0.0
+            || self.scroll_dx.round() != 0.0
+            || self.scroll_dy.round() != 0.0
+    }
+
+    fn take_dispatchable_batch(&mut self) -> MotionBatch {
+        let batch = MotionBatch {
+            pointer_dx: self.pointer_dx.round() as i64,
+            pointer_dy: self.pointer_dy.round() as i64,
+            scroll_dx: self.scroll_dx.round() as i64,
+            scroll_dy: self.scroll_dy.round() as i64,
+        };
+
+        self.pointer_dx -= batch.pointer_dx as f64;
+        self.pointer_dy -= batch.pointer_dy as f64;
+        self.scroll_dx -= batch.scroll_dx as f64;
+        self.scroll_dy -= batch.scroll_dy as f64;
+
+        batch
+    }
+}
+
+impl MotionBatch {
+    fn is_empty(&self) -> bool {
+        self.pointer_dx == 0 && self.pointer_dy == 0 && self.scroll_dx == 0 && self.scroll_dy == 0
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct MousepadRequest {
+    pub dx: Option<f64>,
+    pub dy: Option<f64>,
+    pub scroll: Option<bool>,
+    pub key: Option<String>,
+    pub special_key: Option<u8>,
+    pub alt: Option<bool>,
+    pub ctrl: Option<bool>,
+    pub shift: Option<bool>,
+    #[serde(rename = "super")]
+    pub meta: Option<bool>,
+    pub singleclick: Option<bool>,
+    pub doubleclick: Option<bool>,
+    pub middleclick: Option<bool>,
+    pub rightclick: Option<bool>,
+    pub singlehold: Option<bool>,
+    pub singlerelease: Option<bool>,
+    #[serde(rename = "sendAck")]
+    pub send_ack: Option<bool>,
+    #[serde(rename = "isAck")]
+    pub is_ack: Option<bool>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
+pub struct PresenterRequest {
+    pub dx: Option<f64>,
+    pub dy: Option<f64>,
+    pub stop: Option<bool>,
+}
+
+impl MousepadRequest {
+    pub async fn received_packet(
+        &self,
+        device: &Device,
+        core_tx: mpsc::UnboundedSender<CoreEvent>,
+    ) {
+        if self.is_coalescable_motion() {
+            enqueue_motion_request(self);
+            return;
+        }
+
+        enqueue_input_job(InputJob::Mousepad {
+            request: self.clone(),
+            device: device.device_id.clone(),
+            core_tx,
+        });
+    }
+
+    fn is_coalescable_motion(&self) -> bool {
+        let has_motion = self.dx.unwrap_or_default() != 0.0 || self.dy.unwrap_or_default() != 0.0;
+        has_motion
+            && self.key.is_none()
+            && self.special_key.is_none()
+            && !self.alt.unwrap_or(false)
+            && !self.ctrl.unwrap_or(false)
+            && !self.shift.unwrap_or(false)
+            && !self.meta.unwrap_or(false)
+            && !self.singleclick.unwrap_or(false)
+            && !self.doubleclick.unwrap_or(false)
+            && !self.middleclick.unwrap_or(false)
+            && !self.rightclick.unwrap_or(false)
+            && !self.singlehold.unwrap_or(false)
+            && !self.singlerelease.unwrap_or(false)
+            && !self.send_ack.unwrap_or(false)
+            && !self.is_ack.unwrap_or(false)
+    }
+}
+
+impl PresenterRequest {
+    pub async fn received_packet(&self) {
+        if self.is_coalescable_motion() {
+            enqueue_presenter_motion(self);
+            return;
+        }
+
+        enqueue_input_job(InputJob::Presenter(self.clone()));
+    }
+
+    fn is_coalescable_motion(&self) -> bool {
+        (self.dx.unwrap_or_default() != 0.0 || self.dy.unwrap_or_default() != 0.0)
+            && !self.stop.unwrap_or(false)
+    }
+}
+
+fn input_queue() -> &'static mpsc::Sender<InputJob> {
+    INPUT_QUEUE.get_or_init(|| {
+        let (tx, mut rx) = mpsc::channel(INPUT_QUEUE_CAPACITY);
+
+        tokio::spawn(async move {
+            while let Some(job) = rx.recv().await {
+                match job {
+                    InputJob::Mousepad {
+                        request,
+                        device,
+                        core_tx,
+                    } => {
+                        let request_for_run = request.clone();
+                        let result = tokio::task::spawn_blocking(move || {
+                            run_mousepad_request(&request_for_run)
+                        })
+                        .await;
+
+                        match result {
+                            Ok(Ok(())) => {
+                                if request.send_ack == Some(true) {
+                                    send_mousepad_ack(request, device, core_tx);
+                                }
+                            }
+                            Ok(Err(error)) => {
+                                debug!("[mousepad] failed to handle request: {error}");
+                            }
+                            Err(error) => warn!("[mousepad] handler task failed: {error}"),
+                        }
+                    }
+                    InputJob::FlushMouseMotion => {
+                        flush_mouse_motion().await;
+                    }
+                    InputJob::Presenter(request) => {
+                        if request.stop.unwrap_or(false) {
+                            flush_mouse_motion().await;
+                        }
+
+                        if request.dx.unwrap_or_default() != 0.0
+                            || request.dy.unwrap_or_default() != 0.0
+                        {
+                            match tokio::task::spawn_blocking(move || {
+                                run_presenter_request(&request)
+                            })
+                            .await
+                            {
+                                Ok(Ok(())) => {}
+                                Ok(Err(error)) => {
+                                    debug!("[mousepad] failed presenter request: {error}");
+                                }
+                                Err(error) => {
+                                    warn!("[mousepad] presenter task failed: {error}")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        tx
+    })
+}
+
+fn enqueue_input_job(job: InputJob) -> bool {
+    match input_queue().try_send(job) {
+        Ok(()) => true,
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            if !INPUT_QUEUE_FULL_WARNED.swap(true, Ordering::Relaxed) {
+                warn!(
+                    "[mousepad] remote input queue is full; dropping input until the backend catches up"
+                );
+            }
+            false
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => {
+            if !INPUT_QUEUE_CLOSED_WARNED.swap(true, Ordering::Relaxed) {
+                warn!("[mousepad] remote input queue is closed; dropping input");
+            }
+            false
+        }
+    }
+}
+
+fn motion_accumulator() -> &'static StdMutex<MotionAccumulator> {
+    MOTION_ACCUMULATOR.get_or_init(|| StdMutex::new(MotionAccumulator::default()))
+}
+
+fn enqueue_motion_request(request: &MousepadRequest) {
+    let should_flush = {
+        let mut guard = motion_accumulator().lock().unwrap();
+        guard.add_request(request);
+        guard.has_dispatchable_motion()
+    };
+
+    if should_flush
+        && !MOTION_FLUSH_QUEUED.swap(true, Ordering::AcqRel)
+        && !enqueue_input_job(InputJob::FlushMouseMotion)
+    {
+        MOTION_FLUSH_QUEUED.store(false, Ordering::Release);
+    }
+}
+
+fn enqueue_presenter_motion(request: &PresenterRequest) {
+    let should_flush = {
+        let mut guard = motion_accumulator().lock().unwrap();
+        guard.add_presenter_request(request);
+        guard.has_dispatchable_motion()
+    };
+
+    if should_flush
+        && !MOTION_FLUSH_QUEUED.swap(true, Ordering::AcqRel)
+        && !enqueue_input_job(InputJob::FlushMouseMotion)
+    {
+        MOTION_FLUSH_QUEUED.store(false, Ordering::Release);
+    }
+}
+
+fn take_motion_batch() -> MotionBatch {
+    motion_accumulator()
+        .lock()
+        .unwrap()
+        .take_dispatchable_batch()
+}
+
+fn has_dispatchable_motion() -> bool {
+    motion_accumulator()
+        .lock()
+        .unwrap()
+        .has_dispatchable_motion()
+}
+
+async fn flush_mouse_motion() {
+    for _ in 0..MAX_MOTION_BATCHES_PER_FLUSH {
+        let batch = take_motion_batch();
+        if batch.is_empty() {
+            break;
+        }
+
+        match tokio::task::spawn_blocking(move || run_motion_batch(&batch)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => debug!("[mousepad] failed to handle motion batch: {error}"),
+            Err(error) => warn!("[mousepad] motion handler task failed: {error}"),
+        }
+    }
+
+    MOTION_FLUSH_QUEUED.store(false, Ordering::Release);
+    if has_dispatchable_motion()
+        && !MOTION_FLUSH_QUEUED.swap(true, Ordering::AcqRel)
+        && !enqueue_input_job(InputJob::FlushMouseMotion)
+    {
+        MOTION_FLUSH_QUEUED.store(false, Ordering::Release);
+    }
+}
+
+fn send_mousepad_ack(
+    mut request: MousepadRequest,
+    device: DeviceId,
+    core_tx: mpsc::UnboundedSender<CoreEvent>,
+) {
+    request.send_ack = None;
+    request.is_ack = Some(true);
+    let packet = ProtocolPacket::new(
+        PacketType::MousePadEcho,
+        serde_json::to_value(request).unwrap_or_default(),
+    );
+    let _ = core_tx.send(CoreEvent::SendPacket { device, packet });
+}
+
+fn run_presenter_request(request: &PresenterRequest) -> anyhow::Result<()> {
+    let dx = request.dx.unwrap_or_default();
+    let dy = request.dy.unwrap_or_default();
+
+    if dx != 0.0 || dy != 0.0 {
+        ydotool([
+            "mousemove",
+            "--",
+            &(dx * 1000.0).round().to_string(),
+            &(dy * 1000.0).round().to_string(),
+        ])?;
+    }
+
+    Ok(())
+}
+
+fn run_motion_batch(batch: &MotionBatch) -> anyhow::Result<()> {
+    if batch.pointer_dx != 0 || batch.pointer_dy != 0 {
+        let dx = batch.pointer_dx.to_string();
+        let dy = batch.pointer_dy.to_string();
+        ydotool(["mousemove", "--", &dx, &dy])?;
+    }
+
+    if batch.scroll_dx != 0 || batch.scroll_dy != 0 {
+        let dx = batch.scroll_dx.to_string();
+        let dy = batch.scroll_dy.to_string();
+        ydotool(["mousemove", "-w", "--", &dx, &dy])?;
+    }
+
+    Ok(())
+}
+
+fn run_mousepad_request(request: &MousepadRequest) -> anyhow::Result<()> {
+    if let Some(scroll) = request.scroll {
+        let dx = request.dx.unwrap_or_default();
+        let dy = request.dy.unwrap_or_default();
+        if scroll && (dx != 0.0 || dy != 0.0) {
+            return ydotool([
+                "mousemove",
+                "-w",
+                "--",
+                &dx.round().to_string(),
+                &dy.round().to_string(),
+            ]);
+        }
+    }
+
+    if let (Some(dx), Some(dy)) = (request.dx, request.dy) {
+        return ydotool([
+            "mousemove",
+            "--",
+            &dx.round().to_string(),
+            &dy.round().to_string(),
+        ]);
+    }
+
+    if request.singleclick.unwrap_or(false) {
+        return ydotool(["click", "0xC0"]);
+    }
+    if request.doubleclick.unwrap_or(false) {
+        ydotool(["click", "0xC0"])?;
+        return ydotool(["click", "0xC0"]);
+    }
+    if request.middleclick.unwrap_or(false) {
+        return ydotool(["click", "0xC2"]);
+    }
+    if request.rightclick.unwrap_or(false) {
+        return ydotool(["click", "0xC1"]);
+    }
+    if request.singlehold.unwrap_or(false) {
+        return ydotool(["click", "0x40"]);
+    }
+    if request.singlerelease.unwrap_or(false) {
+        return ydotool(["click", "0x80"]);
+    }
+
+    if let Some(text) = request.key.as_deref() {
+        if text == "\0" {
+            return Ok(());
+        }
+        if !text.is_empty() {
+            return ydotool(["type", "--", text]);
+        }
+    }
+
+    if let Some(special_key) = request.special_key
+        && let Some(code) = special_key_code(special_key)
+    {
+        return ydotool_key_with_modifiers(code, request);
+    }
+
+    debug!("[mousepad] ignored unsupported request: {:?}", request);
+    Ok(())
+}
+
+fn ydotool_key_with_modifiers(code: u16, request: &MousepadRequest) -> anyhow::Result<()> {
+    let mut keys = Vec::new();
+    if request.ctrl.unwrap_or(false) {
+        keys.push(29);
+    }
+    if request.alt.unwrap_or(false) {
+        keys.push(56);
+    }
+    if request.shift.unwrap_or(false) {
+        keys.push(42);
+    }
+    if request.meta.unwrap_or(false) {
+        keys.push(125);
+    }
+
+    for modifier in &keys {
+        ydotool(["key", &format!("{modifier}:1")])?;
+    }
+    ydotool(["key", &format!("{code}:1"), &format!("{code}:0")])?;
+    for modifier in keys.iter().rev() {
+        ydotool(["key", &format!("{modifier}:0")])?;
+    }
+
+    Ok(())
+}
+
+fn ydotool<const N: usize>(args: [&str; N]) -> anyhow::Result<()> {
+    let mut child = match Command::new("ydotool")
+        .args(args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            if !YDOTOOL_MISSING_WARNED.swap(true, Ordering::Relaxed) {
+                warn!("[mousepad] ydotool is not installed; remote input is unavailable");
+            }
+            return Err(e.into());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let started = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let mut stderr = Vec::new();
+                if let Some(mut pipe) = child.stderr.take() {
+                    let _ = pipe.read_to_end(&mut stderr);
+                }
+                return handle_ydotool_status(status, &stderr);
+            }
+            Ok(None) if started.elapsed() >= YDOTOOL_TIMEOUT => {
+                let _ = child.kill();
+                let _ = child.wait();
+                if !YDOTOOL_TIMEOUT_WARNED.swap(true, Ordering::Relaxed) {
+                    warn!(
+                        "[mousepad] ydotool did not exit within {}s; remote input backend appears stuck",
+                        YDOTOOL_TIMEOUT.as_secs()
+                    );
+                }
+                anyhow::bail!("ydotool timed out");
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
+
+fn handle_ydotool_status(status: ExitStatus, stderr: &[u8]) -> anyhow::Result<()> {
+    if status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(stderr);
+    let message = stderr.trim();
+    if message.contains("ydotoold is running") || message.contains("failed to connect socket") {
+        if !YDOTOOL_DAEMON_WARNED.swap(true, Ordering::Relaxed) {
+            warn!(
+                "[mousepad] ydotoold is not running or its socket is unavailable; remote input is unavailable"
+            );
+        }
+    } else if status.code() == Some(2) && message.is_empty() {
+        if !YDOTOOL_DAEMON_WARNED.swap(true, Ordering::Relaxed) {
+            warn!(
+                "[mousepad] ydotool exited with status 2; ydotoold may not be running (run 'systemctl --user enable --now ydotoold')"
+            );
+        }
+    } else if message.is_empty() {
+        warn!("[mousepad] ydotool exited with status {}", status);
+    } else {
+        warn!(
+            "[mousepad] ydotool exited with status {}: {message}",
+            status
+        );
+    }
+
+    anyhow::bail!("ydotool exited with status {}", status)
+}
+
+fn special_key_code(key: u8) -> Option<u16> {
+    Some(match key {
+        1 => 14,
+        2 => 15,
+        3 => 101,
+        4 => 105,
+        5 => 103,
+        6 => 106,
+        7 => 108,
+        8 => 104,
+        9 => 109,
+        10 => 102,
+        11 => 107,
+        12 => 28,
+        13 => 111,
+        14 => 1,
+        15 => 99,
+        16 => 70,
+        21 => 59,
+        22 => 60,
+        23 => 61,
+        24 => 62,
+        25 => 63,
+        26 => 64,
+        27 => 65,
+        28 => 66,
+        29 => 67,
+        30 => 68,
+        31 => 87,
+        32 => 88,
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_kdeconnect_special_keys_to_linux_input_codes() {
+        assert_eq!(special_key_code(1), Some(14));
+        assert_eq!(special_key_code(12), Some(28));
+        assert_eq!(special_key_code(32), Some(88));
+        assert_eq!(special_key_code(99), None);
+    }
+
+    #[test]
+    fn coalesces_plain_motion_but_not_clicks_or_acks() {
+        assert!(
+            MousepadRequest {
+                dx: Some(1.0),
+                dy: Some(2.0),
+                ..Default::default()
+            }
+            .is_coalescable_motion()
+        );
+
+        assert!(
+            MousepadRequest {
+                dx: Some(0.0),
+                dy: Some(2.0),
+                scroll: Some(true),
+                ..Default::default()
+            }
+            .is_coalescable_motion()
+        );
+
+        assert!(
+            !MousepadRequest {
+                dx: Some(1.0),
+                dy: Some(2.0),
+                singleclick: Some(true),
+                ..Default::default()
+            }
+            .is_coalescable_motion()
+        );
+
+        assert!(
+            !MousepadRequest {
+                dx: Some(1.0),
+                dy: Some(2.0),
+                send_ack: Some(true),
+                ..Default::default()
+            }
+            .is_coalescable_motion()
+        );
+    }
+
+    #[test]
+    fn parses_presenter_schema_and_coalesces_motion_only() {
+        let motion: PresenterRequest = serde_json::from_value(serde_json::json!({
+            "dx": 0.01,
+            "dy": -0.02
+        }))
+        .unwrap();
+        assert_eq!(motion.dx, Some(0.01));
+        assert_eq!(motion.dy, Some(-0.02));
+        assert!(motion.is_coalescable_motion());
+
+        let stop: PresenterRequest = serde_json::from_value(serde_json::json!({
+            "stop": true
+        }))
+        .unwrap();
+        assert_eq!(stop.stop, Some(true));
+        assert!(!stop.is_coalescable_motion());
+    }
+
+    #[test]
+    fn motion_accumulator_keeps_fractional_remainder() {
+        let mut accumulator = MotionAccumulator::default();
+        accumulator.add_request(&MousepadRequest {
+            dx: Some(0.4),
+            dy: Some(0.4),
+            ..Default::default()
+        });
+        assert!(!accumulator.has_dispatchable_motion());
+
+        accumulator.add_request(&MousepadRequest {
+            dx: Some(0.4),
+            dy: Some(0.4),
+            ..Default::default()
+        });
+        assert!(accumulator.has_dispatchable_motion());
+
+        let batch = accumulator.take_dispatchable_batch();
+        assert_eq!(batch.pointer_dx, 1);
+        assert_eq!(batch.pointer_dy, 1);
+        assert!(!accumulator.has_dispatchable_motion());
+    }
+
+    #[test]
+    fn presenter_motion_reuses_mouse_motion_batching() {
+        let mut accumulator = MotionAccumulator::default();
+        accumulator.add_presenter_request(&PresenterRequest {
+            dx: Some(0.0014),
+            dy: Some(-0.0026),
+            stop: None,
+        });
+
+        assert!(accumulator.has_dispatchable_motion());
+        let batch = accumulator.take_dispatchable_batch();
+        assert_eq!(batch.pointer_dx, 1);
+        assert_eq!(batch.pointer_dy, -3);
+        assert_eq!(batch.scroll_dx, 0);
+        assert_eq!(batch.scroll_dy, 0);
+    }
+
+    #[test]
+    fn presenter_stop_with_motion_is_not_coalescable() {
+        let stop_with_motion = PresenterRequest {
+            dx: Some(0.01),
+            dy: Some(-0.02),
+            stop: Some(true),
+        };
+        assert!(!stop_with_motion.is_coalescable_motion());
+
+        let stop_only = PresenterRequest {
+            dx: None,
+            dy: None,
+            stop: Some(true),
+        };
+        assert!(!stop_only.is_coalescable_motion());
+    }
+
+    #[test]
+    fn presenter_accumulator_scales_by_thousand() {
+        let mut accumulator = MotionAccumulator::default();
+        accumulator.add_presenter_request(&PresenterRequest {
+            dx: Some(1.5),
+            dy: Some(-0.003),
+            stop: None,
+        });
+        assert!(accumulator.has_dispatchable_motion());
+        let batch = accumulator.take_dispatchable_batch();
+        assert_eq!(batch.pointer_dx, 1500);
+        assert_eq!(batch.pointer_dy, -3);
+    }
+
+    #[test]
+    fn presenter_received_packet_returns_immediately() {
+        use std::time::Duration;
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let passed = rt.block_on(async {
+            let request = PresenterRequest {
+                dx: Some(0.5),
+                dy: Some(-0.3),
+                ..Default::default()
+            };
+
+            tokio::time::timeout(Duration::from_millis(500), request.received_packet())
+                .await
+                .is_ok()
+        });
+
+        rt.shutdown_background();
+
+        assert!(passed, "presenter received_packet must return immediately");
+    }
+
+    #[test]
+    fn presenter_stop_received_packet_returns_immediately() {
+        use std::time::Duration;
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let passed = rt.block_on(async {
+            let request = PresenterRequest {
+                dx: None,
+                dy: None,
+                stop: Some(true),
+            };
+
+            tokio::time::timeout(Duration::from_millis(500), request.received_packet())
+                .await
+                .is_ok()
+        });
+
+        rt.shutdown_background();
+
+        assert!(
+            passed,
+            "presenter stop received_packet must return immediately"
+        );
     }
 }

--- a/kdeconnect-core/src/plugins/mpris.rs
+++ b/kdeconnect-core/src/plugins/mpris.rs
@@ -7,7 +7,7 @@ use tracing::debug;
 use zbus::interface;
 
 use crate::{
-    device::{Device, DeviceManager},
+    device::{Device, DeviceManager, PairState},
     plugin_interface::Plugin,
     protocol::{DeviceFile, DevicePayload, PacketPayloadTransferInfo, PacketType, ProtocolPacket},
 };
@@ -226,7 +226,10 @@ pub fn get_all_mpris_player_names() -> Vec<String> {
         Err(_) => return vec![],
     };
     match finder.find_all() {
-        Ok(players) => players.into_iter().map(|p| p.identity().to_string()).collect(),
+        Ok(players) => players
+            .into_iter()
+            .map(|p| p.identity().to_string())
+            .collect(),
         Err(_) => vec![],
     }
 }
@@ -245,108 +248,115 @@ impl MprisRequest {
     ) {
         debug!("mpris request received: {:?}", self);
 
-        if self.request_player_list == Some(true) {
-            debug!("MPRIS Player list requested");
-            let player_list = get_all_mpris_player_names();
-            debug!("Sending player list: {:?}", player_list);
-            let packet = ProtocolPacket::new(
-                PacketType::Mpris,
-                serde_json::to_value(Mpris::List {
-                    player_list,
-                    supports_album_art_payload: true,
-                })
-                .unwrap(),
-            );
-            let _ = core_tx.send(crate::event::CoreEvent::SendPacket {
-                device: device.device_id.clone(),
-                packet,
-            });
-            return;
-        }
+        let request = self.clone();
+        let device_id = device.device_id.clone();
 
-        if let Some(player_name) = &self.player {
-            {
-                if let Ok(player) = get_mpris_players(Some(player_name)) {
-                    if let Some(seek_us) = self.seek {
-                        let _ = player.seek(seek_us);
-                    }
+        tokio::task::spawn_blocking(move || {
+            if request.request_player_list == Some(true) {
+                debug!("MPRIS Player list requested");
+                let player_list = get_all_mpris_player_names();
+                debug!("Sending player list: {:?}", player_list);
+                let packet = ProtocolPacket::new(
+                    PacketType::Mpris,
+                    serde_json::to_value(Mpris::List {
+                        player_list,
+                        supports_album_art_payload: true,
+                    })
+                    .unwrap(),
+                );
+                let _ = core_tx.send(crate::event::CoreEvent::SendPacket {
+                    device: device_id,
+                    packet,
+                });
+                return;
+            }
 
-                    if let Some(vol) = self.set_volume {
-                        let _ = player.set_volume(vol as f64 / 100.0);
-                    }
+            let Some(player_name) = request.player.as_deref() else {
+                return;
+            };
 
-                    if let Some(loop_status) = self.set_loop_status {
-                        let status = match loop_status {
-                            MprisLoopStatus::None => mpris::LoopStatus::None,
-                            MprisLoopStatus::Track => mpris::LoopStatus::Track,
-                            MprisLoopStatus::Playlist => mpris::LoopStatus::Playlist,
-                        };
-                        let _ = player.set_loop_status(status);
-                    }
+            if let Ok(player) = get_mpris_players(Some(player_name)) {
+                if let Some(seek_us) = request.seek {
+                    let _ = player.seek(seek_us);
+                }
 
-                    if let Some(position_ms) = self.set_position
-                        && let Ok(metadata) = player.get_metadata()
-                        && let Some(track_id) = metadata.track_id()
-                    {
-                        let duration = std::time::Duration::from_millis(position_ms as u64);
-                        let _ = player.set_position(track_id, &duration);
-                    }
+                if let Some(vol) = request.set_volume {
+                    let _ = player.set_volume(vol as f64 / 100.0);
+                }
 
-                    if let Some(shuffle) = self.set_shuffle {
-                        let _ = player.set_shuffle(shuffle);
-                    }
+                if let Some(loop_status) = request.set_loop_status {
+                    let status = match loop_status {
+                        MprisLoopStatus::None => mpris::LoopStatus::None,
+                        MprisLoopStatus::Track => mpris::LoopStatus::Track,
+                        MprisLoopStatus::Playlist => mpris::LoopStatus::Playlist,
+                    };
+                    let _ = player.set_loop_status(status);
+                }
 
-                    if let Some(command) = self.action {
-                        let _ = match command {
-                            MprisAction::Play => player.play(),
-                            MprisAction::Pause => player.pause(),
-                            MprisAction::PlayPause => player.play_pause(),
-                            MprisAction::Stop => player.stop(),
-                            MprisAction::Next => player.next(),
-                            MprisAction::Previous => player.previous(),
-                        };
-                    }
+                if let Some(position_ms) = request.set_position
+                    && let Ok(metadata) = player.get_metadata()
+                    && let Some(track_id) = metadata.track_id()
+                {
+                    let duration = std::time::Duration::from_millis(position_ms as u64);
+                    let _ = player.set_position(track_id, &duration);
+                }
+
+                if let Some(shuffle) = request.set_shuffle {
+                    let _ = player.set_shuffle(shuffle);
+                }
+
+                if let Some(command) = request.action {
+                    let _ = match command {
+                        MprisAction::Play => player.play(),
+                        MprisAction::Pause => player.pause(),
+                        MprisAction::PlayPause => player.play_pause(),
+                        MprisAction::Stop => player.stop(),
+                        MprisAction::Next => player.next(),
+                        MprisAction::Previous => player.previous(),
+                    };
                 }
             }
 
-            if let Some(album_art_url) = &self.album_art_url {
+            if let Some(album_art_url) = &request.album_art_url {
                 let Ok(player_info) = MprisPlayer::new(Some(player_name)) else {
                     return;
                 };
                 let art = player_info.album_art_url.clone();
 
-                let path = album_art_url.strip_prefix("file://");
-
-                let Some(path) = path else {
+                let Some(path) = album_art_url.strip_prefix("file://") else {
                     return;
                 };
+                let path = path.to_string();
+                let player_name = player_name.to_string();
 
-                if let Ok(file) = DeviceFile::open(path).await {
-                    let payload = DevicePayload::from(file);
+                tokio::spawn(async move {
+                    if let Ok(file) = DeviceFile::open(&path).await {
+                        let payload = DevicePayload::from(file);
 
-                    let construct_packet = ProtocolPacket::new_with_payload(
-                        PacketType::Mpris,
-                        serde_json::to_value(Mpris::TransferringArt {
-                            player: player_name.clone(),
-                            album_art_url: art.unwrap_or(path.to_string()),
-                            transferring_album_art: true,
-                        })
-                        .unwrap(),
-                        payload.size,
-                        None,
-                    );
+                        let construct_packet = ProtocolPacket::new_with_payload(
+                            PacketType::Mpris,
+                            serde_json::to_value(Mpris::TransferringArt {
+                                player: player_name,
+                                album_art_url: art.unwrap_or(path),
+                                transferring_album_art: true,
+                            })
+                            .unwrap(),
+                            payload.size,
+                            None,
+                        );
 
-                    let _ = core_tx.send(crate::event::CoreEvent::SendPaylod {
-                        device: device.device_id.clone(),
-                        packet: construct_packet,
-                        payload: Box::new(payload.buf),
-                        payload_size: payload.size,
-                    });
-                }
+                        let _ = core_tx.send(crate::event::CoreEvent::SendPaylod {
+                            device: device_id,
+                            packet: construct_packet,
+                            payload: Box::new(payload.buf),
+                            payload_size: payload.size,
+                        });
+                    }
+                });
                 return;
             }
 
-            if (self.request_now_playing == Some(true) || self.request_volume == Some(true))
+            if (request.request_now_playing == Some(true) || request.request_volume == Some(true))
                 && let Ok(player_info) = MprisPlayer::new(Some(player_name))
             {
                 let construct_packet = ProtocolPacket::new(
@@ -355,11 +365,11 @@ impl MprisRequest {
                 );
 
                 let _ = core_tx.send(crate::event::CoreEvent::SendPacket {
-                    device: device.device_id.clone(),
+                    device: device_id,
                     packet: construct_packet,
                 });
             }
-        }
+        });
     }
 
     pub async fn send_packet(
@@ -380,9 +390,16 @@ impl MprisRequest {
 }
 
 /// Telephony plugin sends true (call active) / false (call ended) here.
-/// Initialised when monitor_mpris starts.
+/// Initiaised at service start time so telephony signals are never dropped
+/// before monitor_mpris has finished its first setup iteration.
 static TELEPHONY_CALL_TX: std::sync::OnceLock<std::sync::mpsc::SyncSender<bool>> =
     std::sync::OnceLock::new();
+
+/// Ensures the telephony signal channel is set up. Safe to call multiple times.
+pub fn init_telephony_signal() {
+    let (call_tx, _call_rx) = std::sync::mpsc::sync_channel::<bool>(1);
+    TELEPHONY_CALL_TX.set(call_tx).ok();
+}
 
 /// Called by the telephony plugin to signal call state changes.
 pub fn telephony_call_signal() -> Option<&'static std::sync::mpsc::SyncSender<bool>> {
@@ -397,7 +414,8 @@ pub fn monitor_mpris(
     let ctx_sup = core_tx.clone();
 
     tokio::task::spawn_blocking(move || {
-       let (call_tx, call_rx) = std::sync::mpsc::sync_channel::<bool>(1);
+        // Ensure telephony signal channel exists before we start the loop.
+        let (call_tx, call_rx) = std::sync::mpsc::sync_channel::<bool>(1);
         TELEPHONY_CALL_TX.set(call_tx).ok();
 
         // Holds Player objects paused for an active call — keeping them alive
@@ -412,18 +430,18 @@ pub fn monitor_mpris(
             if let Ok(call_active) = call_rx.try_recv() {
                 if call_active {
                     paused_players.clear();
-                    if let Ok(finder) = mpris::PlayerFinder::new() {
-                        if let Ok(players) = finder.find_all() {
-                            for player in players {
-                                if matches!(
-                                    player.get_playback_status(),
-                                    Ok(mpris::PlaybackStatus::Playing)
-                                ) {
-                                    let name = player.identity().to_string();
-                                    if player.pause().is_ok() {
-                                        tracing::info!("[mpris] paused for call: {}", name);
-                                        paused_players.push(player);
-                                    }
+                    if let Ok(finder) = mpris::PlayerFinder::new()
+                        && let Ok(players) = finder.find_all()
+                    {
+                        for player in players {
+                            if matches!(
+                                player.get_playback_status(),
+                                Ok(mpris::PlaybackStatus::Playing)
+                            ) {
+                                let name = player.identity().to_string();
+                                if player.pause().is_ok() {
+                                    tracing::info!("[mpris] paused for call: {}", name);
+                                    paused_players.push(player);
                                 }
                             }
                         }
@@ -456,6 +474,9 @@ pub fn monitor_mpris(
                 tokio::spawn(async move {
                     let devices = dm.get_devices().await;
                     for device in devices {
+                        if device.pair_state != PairState::Paired {
+                            continue;
+                        }
                         let _ = ctx.send(crate::event::CoreEvent::SendPacket {
                             device: device.device_id.clone(),
                             packet: packet.clone(),
@@ -512,6 +533,9 @@ pub fn monitor_mpris(
                                         tokio::spawn(async move {
                                             let devices = dm.get_devices().await;
                                             for device in devices {
+                                                if device.pair_state != PairState::Paired {
+                                                    continue;
+                                                }
                                                 let _ =
                                                     ctx.send(crate::event::CoreEvent::SendPacket {
                                                         device: device.device_id.clone(),
@@ -594,7 +618,10 @@ impl PhoneMprisPlayer {
         self.send_request(request).await;
     }
 
-    async fn play_pause(&self, #[zbus(signal_emitter)] emitter: zbus::object_server::SignalEmitter<'_>) {
+    async fn play_pause(
+        &self,
+        #[zbus(signal_emitter)] emitter: zbus::object_server::SignalEmitter<'_>,
+    ) {
         let mut state = self.player_state.write().await;
         let is_playing = state.is_playing.unwrap_or(false);
         state.is_playing = Some(!is_playing);
@@ -861,7 +888,7 @@ pub fn expose_phone_mpris(
                                                 let emitter = iface_ref.signal_emitter();
                                                 let iface = iface_ref.get().await;
                                                 let _ = iface
-                                                    .playback_status_changed(&emitter)
+                                                    .playback_status_changed(emitter)
                                                     .await;
                                             }
                                         }
@@ -911,10 +938,24 @@ pub fn expose_phone_mpris(
                                 device_id.0
                             );
                         }
+                        crate::event::ConnectionEvent::PairStateChanged((
+                            device_id,
+                            PairState::NotPaired,
+                        )) => {
+                            active_players.retain(|_, conn| conn.device_id != device_id);
+                            tracing::info!(
+                                "Removed MPRIS players for unpaired device: {}",
+                                device_id.0
+                            );
+                        }
                         _ => {}
                     }
                 }
                 _ = interval.tick() => {
+                    // Skip polling when no players are actively registered.
+                    if active_players.is_empty() {
+                        continue;
+                    }
                     // Ask each phone to refresh now-playing for all its players.
                     for player_conn in active_players.values() {
                         let player_name = player_conn.player_state.read().await.player.clone();
@@ -974,4 +1015,116 @@ async fn register_phone_player(
         .await?;
 
     Ok((conn, player_state))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::{Device, DeviceId};
+    use std::time::Duration;
+
+    #[test]
+    fn received_packet_returns_immediately_without_blocking() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let passed = rt.block_on(async {
+            let request = MprisRequest {
+                request_player_list: Some(true),
+                ..Default::default()
+            };
+            let device = Device {
+                device_id: DeviceId("test-mpris-nonblock".into()),
+                ..Default::default()
+            };
+            let (core_tx, _core_rx) = tokio::sync::mpsc::unbounded_channel();
+
+            tokio::time::timeout(
+                Duration::from_millis(500),
+                request.received_packet(&device, core_tx),
+            )
+            .await
+            .is_ok()
+        });
+
+        rt.shutdown_background();
+
+        assert!(
+            passed,
+            "mpris received_packet must return immediately without blocking on D-Bus calls"
+        );
+    }
+
+    #[test]
+    fn control_commands_do_not_block_event_loop() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let passed = rt.block_on(async {
+            let request = MprisRequest {
+                player: Some("NonexistentPlayer".to_string()),
+                action: Some(MprisAction::PlayPause),
+                set_volume: Some(50),
+                ..Default::default()
+            };
+            let device = Device {
+                device_id: DeviceId("test-mpris-control-nonblock".into()),
+                ..Default::default()
+            };
+            let (core_tx, _core_rx) = tokio::sync::mpsc::unbounded_channel();
+
+            tokio::time::timeout(
+                Duration::from_millis(500),
+                request.received_packet(&device, core_tx),
+            )
+            .await
+            .is_ok()
+        });
+
+        rt.shutdown_background();
+
+        assert!(
+            passed,
+            "mpris control commands must not block the event loop"
+        );
+    }
+
+    #[test]
+    fn now_playing_request_does_not_block_event_loop() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let passed = rt.block_on(async {
+            let request = MprisRequest {
+                player: Some("NonexistentPlayer".to_string()),
+                request_now_playing: Some(true),
+                ..Default::default()
+            };
+            let device = Device {
+                device_id: DeviceId("test-mpris-nowplaying-nonblock".into()),
+                ..Default::default()
+            };
+            let (core_tx, _core_rx) = tokio::sync::mpsc::unbounded_channel();
+
+            tokio::time::timeout(
+                Duration::from_millis(500),
+                request.received_packet(&device, core_tx),
+            )
+            .await
+            .is_ok()
+        });
+
+        rt.shutdown_background();
+
+        assert!(
+            passed,
+            "mpris now-playing request must not block the event loop"
+        );
+    }
 }

--- a/kdeconnect-core/src/plugins/notification.rs
+++ b/kdeconnect-core/src/plugins/notification.rs
@@ -1,7 +1,24 @@
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use std::{
+    collections::{HashMap, HashSet},
+    process::{Command, Stdio},
+    sync::Mutex,
+};
 use tokio::sync::mpsc;
+use tracing::{debug, warn};
 
-use crate::plugin_interface::Plugin;
+use crate::{
+    device::Device,
+    event::CoreEvent,
+    plugin_interface::Plugin,
+    protocol::{PacketType, ProtocolPacket},
+};
+
+static NOTIFICATION_IDS: Lazy<Mutex<HashMap<String, u32>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+static PROGRAMMATIC_CLOSES: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct Notification {
@@ -20,9 +37,10 @@ pub struct Notification {
     pub actions: Option<Vec<String>>,
     #[serde(rename = "payloadHash")]
     pub payload_hash: Option<String>,
+    #[serde(rename = "isCancel")]
+    pub is_cancel: Option<bool>,
 }
 
-#[allow(dead_code)]
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct NotificationAction {
     pub key: Option<String>,
@@ -30,14 +48,13 @@ pub struct NotificationAction {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
-#[allow(dead_code)]
 pub struct NotificationReply {
     #[serde(rename = "requestReplyId")]
     pub request_reply_id: Option<String>,
     pub message: Option<String>,
 }
 
-#[allow(dead_code)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct NotificationRequest {
     pub cancel: Option<String>,
     pub request: Option<bool>,
@@ -52,61 +69,429 @@ impl Plugin for Notification {
 impl Notification {
     pub async fn received_packet(
         &self,
-        device: &crate::device::Device,
-        _core_event: mpsc::UnboundedSender<crate::event::CoreEvent>,
+        device: &Device,
+        core_event: mpsc::UnboundedSender<CoreEvent>,
     ) {
-        // Implementation for handling received notifications would go here.
-        let _device_id = device.device_id.clone();
+        let key = self.id.clone().unwrap_or_default();
+
+        if self.is_cancel.unwrap_or(false) {
+            tokio::spawn(async move { close_notification(&key).await });
+            return;
+        }
+
+        let device_id = device.device_id.clone();
         let app_name = self.app_name.clone().unwrap_or_default();
         let Some(title) = self.title.clone() else {
             return;
         };
-        let Some(text) = self.text.clone() else {
-            return;
-        };
-        let _key = self.id.clone().unwrap_or_default();
-
+        let text = self.text.clone().unwrap_or_default();
         let actions = self.actions.clone().unwrap_or_default();
+        let reply_id = self.request_reply_id.clone();
+        let original = self.clone();
 
-        let _ = tokio::task::spawn_blocking(move || {
-            // let mut notify_action: Option<String> = None;
+        let old_handle_id = if !key.is_empty() {
+            NOTIFICATION_IDS
+                .lock()
+                .ok()
+                .and_then(|mut ids| ids.remove(&key))
+        } else {
+            None
+        };
+
+        if old_handle_id.is_some()
+            && !key.is_empty()
+            && let Ok(mut closed) = PROGRAMMATIC_CLOSES.lock()
+        {
+            closed.insert(key.clone());
+        }
+
+        tokio::task::spawn_blocking(move || {
+            if let Some(old_id) = old_handle_id {
+                close_notification_sync(old_id);
+            }
 
             let mut notify = notify_rust::Notification::new();
             notify.appname(&app_name);
-            notify.summary(&title);
-            notify.body(&text);
+            notify.summary(if app_name.is_empty() {
+                &title
+            } else {
+                &app_name
+            });
+            notify.body(&notification_body(&title, &text, &app_name));
 
             for action in actions.iter() {
                 notify.action(action, action);
             }
 
-            notify
-                // .action("clicked", "Click to reply")
-                .hint(notify_rust::Hint::Resident(true))
-                .show()
-                .unwrap();
-            // .wait_for_action(|action| {
-            //     notify_action = Some(action.to_string());
-            // });
+            if reply_id.is_some() {
+                notify.action("reply", "Reply");
+            }
 
-            // if let Some(action) = notify_action {
-            //     let packet = crate::protocol::ProtocolPacket::new(
-            //         crate::protocol::PacketType::NotificationAction,
-            //         serde_json::to_value(NotificationAction {
-            //             key: Some(key),
-            //             action: Some(action),
-            //         })
-            //         .unwrap_or_default(),
-            //     );
-            //
-            //     core_event
-            //         .send(crate::event::CoreEvent::SendPacket {
-            //             device: device_id,
-            //             packet,
-            //         })
-            //         .unwrap_or_default();
-            // }
-        })
+            let handle = match notify.hint(notify_rust::Hint::Resident(true)).show() {
+                Ok(handle) => handle,
+                Err(e) => {
+                    warn!("[notification] failed to show notification: {}", e);
+                    return;
+                }
+            };
+
+            if !key.is_empty()
+                && let Ok(mut ids) = NOTIFICATION_IDS.lock()
+            {
+                ids.insert(key.clone(), handle.id());
+            }
+
+            handle.wait_for_action(|action| {
+                if !key.is_empty()
+                    && let Ok(mut ids) = NOTIFICATION_IDS.lock()
+                {
+                    ids.remove(&key);
+                }
+
+                match action {
+                    "__closed" => {
+                        let was_programmatic = !key.is_empty()
+                            && PROGRAMMATIC_CLOSES
+                                .lock()
+                                .ok()
+                                .map(|mut c| c.remove(&key))
+                                .unwrap_or(false);
+
+                        if !was_programmatic && !key.is_empty() {
+                            let packet = ProtocolPacket::new(
+                                PacketType::NotificationRequest,
+                                serde_json::json!({ "cancel": key }),
+                            );
+                            let _ = core_event.send(CoreEvent::SendPacket {
+                                device: device_id,
+                                packet,
+                            });
+                        }
+                    }
+                    "reply" => {
+                        if let Some(request_reply_id) = reply_id
+                            && let Some(message) = prompt_reply(&original)
+                        {
+                            let packet = ProtocolPacket::new(
+                                PacketType::NotificationReply,
+                                serde_json::to_value(NotificationReply {
+                                    request_reply_id: Some(request_reply_id),
+                                    message: Some(message),
+                                })
+                                .unwrap_or_default(),
+                            );
+                            let _ = core_event.send(CoreEvent::SendPacket {
+                                device: device_id,
+                                packet,
+                            });
+                        }
+                    }
+                    selected => {
+                        let packet = ProtocolPacket::new(
+                            PacketType::NotificationAction,
+                            serde_json::to_value(NotificationAction {
+                                key: Some(key.clone()),
+                                action: Some(selected.to_string()),
+                            })
+                            .unwrap_or_default(),
+                        );
+                        let _ = core_event.send(CoreEvent::SendPacket {
+                            device: device_id,
+                            packet,
+                        });
+                    }
+                }
+            });
+        });
+    }
+}
+
+impl NotificationRequest {
+    pub async fn received_packet(&self) {
+        if let Some(cancel) = &self.cancel {
+            let cancel = cancel.clone();
+            tokio::spawn(async move { close_notification(&cancel).await });
+        }
+
+        if self.request.unwrap_or(false) {
+            debug!(
+                "[notification] phone requested local notification list; passive desktop notification mirroring is not available yet"
+            );
+        }
+    }
+}
+
+fn notification_body(title: &str, text: &str, app_name: &str) -> String {
+    if app_name.is_empty() || app_name == title {
+        return text.to_string();
+    }
+
+    if text.is_empty() {
+        title.to_string()
+    } else {
+        format!("{}: {}", title, text)
+    }
+}
+
+fn prompt_reply(notification: &Notification) -> Option<String> {
+    let title = notification
+        .title
+        .as_deref()
+        .or(notification.app_name.as_deref())
+        .unwrap_or("Reply");
+    let text = notification.text.as_deref().unwrap_or_default();
+
+    let output = Command::new("zenity")
+        .arg("--entry")
+        .arg("--title")
+        .arg(format!("Reply to {}", title))
+        .arg("--text")
+        .arg(text)
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let message = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if message.is_empty() {
+        None
+    } else {
+        Some(message)
+    }
+}
+
+fn close_notification_sync(id: u32) {
+    let Ok(connection) = zbus::blocking::Connection::session() else {
+        return;
+    };
+    let _ = connection.call_method(
+        Some("org.freedesktop.Notifications"),
+        "/org/freedesktop/Notifications",
+        Some("org.freedesktop.Notifications"),
+        "CloseNotification",
+        &(id),
+    );
+}
+
+async fn close_notification(key: &str) {
+    let Some(id) = NOTIFICATION_IDS
+        .lock()
+        .ok()
+        .and_then(|mut ids| ids.remove(key))
+    else {
+        return;
+    };
+
+    let connection = match zbus::Connection::session().await {
+        Ok(connection) => connection,
+        Err(e) => {
+            warn!("[notification] failed to connect to session bus: {}", e);
+            return;
+        }
+    };
+
+    if let Err(e) = connection
+        .call_method(
+            Some("org.freedesktop.Notifications"),
+            "/org/freedesktop/Notifications",
+            Some("org.freedesktop.Notifications"),
+            "CloseNotification",
+            &(id),
+        )
+        .await
+    {
+        warn!("[notification] failed to close notification {}: {}", id, e);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::{Device, DeviceId};
+    use std::time::Duration;
+
+    fn test_notification(key: &str, title: &str) -> Notification {
+        Notification {
+            id: Some(key.to_string()),
+            title: Some(title.to_string()),
+            app_name: Some("TestApp".to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn formats_remote_notification_body_like_gsconnect() {
+        assert_eq!(
+            notification_body("Message", "Hello", "Messages"),
+            "Message: Hello"
+        );
+        assert_eq!(notification_body("Messages", "Hello", "Messages"), "Hello");
+    }
+
+    #[test]
+    fn received_packet_returns_immediately_without_blocking() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let passed = rt.block_on(async {
+            let notification = test_notification("nonblock-test-1", "Test Title");
+            let device = Device {
+                device_id: DeviceId("test-device-nonblock".to_string()),
+                ..Default::default()
+            };
+            let (core_tx, _core_rx) = tokio::sync::mpsc::unbounded_channel();
+
+            tokio::time::timeout(
+                Duration::from_millis(500),
+                notification.received_packet(&device, core_tx),
+            )
+            .await
+            .is_ok()
+        });
+
+        NOTIFICATION_IDS.lock().unwrap().remove("nonblock-test-1");
+        rt.shutdown_background();
+
+        assert!(
+            passed,
+            "received_packet must return immediately without blocking on notification interaction"
+        );
+    }
+
+    #[test]
+    fn duplicate_key_removes_old_entry_from_map() {
+        let key = "dedup-test-key";
+        NOTIFICATION_IDS
+            .lock()
+            .unwrap()
+            .insert(key.to_string(), 99999);
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            let notification = test_notification(key, "Duplicate Test");
+            let device = Device {
+                device_id: DeviceId("test-device-dedup".to_string()),
+                ..Default::default()
+            };
+            let (core_tx, _core_rx) = tokio::sync::mpsc::unbounded_channel();
+            notification.received_packet(&device, core_tx).await;
+        });
+
+        let has_old = NOTIFICATION_IDS.lock().unwrap().get(key).copied();
+        NOTIFICATION_IDS.lock().unwrap().remove(key);
+        rt.shutdown_background();
+
+        assert_ne!(
+            has_old,
+            Some(99999),
+            "old notification handle must be evicted when a new notification arrives with the same key"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_notification_returns_immediately() {
+        let notification = Notification {
+            id: Some("cancel-nonblock-test".to_string()),
+            is_cancel: Some(true),
+            ..Default::default()
+        };
+        let device = Device {
+            device_id: DeviceId("test-device-cancel".to_string()),
+            ..Default::default()
+        };
+        let (core_tx, _core_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(500),
+            notification.received_packet(&device, core_tx),
+        )
         .await;
+
+        assert!(
+            result.is_ok(),
+            "cancel notification must return immediately"
+        );
+    }
+
+    #[test]
+    fn duplicate_notification_does_not_send_cancel_to_phone() {
+        let key = "dedup-no-cancel-test";
+        NOTIFICATION_IDS
+            .lock()
+            .unwrap()
+            .insert(key.to_string(), 99998);
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            let notification = test_notification(key, "Dedup Title");
+            let device = Device {
+                device_id: DeviceId("test-device-dedup-nocancel".to_string()),
+                ..Default::default()
+            };
+            let (core_tx, _core_rx) = tokio::sync::mpsc::unbounded_channel();
+            notification.received_packet(&device, core_tx).await;
+        });
+
+        let was_programmatic = PROGRAMMATIC_CLOSES.lock().unwrap().remove(key);
+
+        NOTIFICATION_IDS.lock().unwrap().remove(key);
+        rt.shutdown_background();
+
+        assert!(
+            was_programmatic,
+            "duplicate notification key must be recorded in PROGRAMMATIC_CLOSES \
+             so the old notification's __closed callback does not send cancel to the phone"
+        );
+    }
+
+    #[test]
+    fn multiple_notifications_processed_without_serialization() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let elapsed = rt.block_on(async {
+            let device = Device {
+                device_id: DeviceId("test-device-multi".to_string()),
+                ..Default::default()
+            };
+
+            let start = std::time::Instant::now();
+            for i in 0..10 {
+                let notification =
+                    test_notification(&format!("multi-notif-{}", i), &format!("Title {}", i));
+                let (core_tx, _core_rx) = tokio::sync::mpsc::unbounded_channel();
+                notification.received_packet(&device, core_tx).await;
+            }
+            start.elapsed()
+        });
+
+        let mut ids = NOTIFICATION_IDS.lock().unwrap();
+        for i in 0..10 {
+            ids.remove(&format!("multi-notif-{}", i));
+        }
+        drop(ids);
+        rt.shutdown_background();
+
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "10 notifications must be dispatched without blocking; took {:?}",
+            elapsed
+        );
     }
 }

--- a/kdeconnect-core/src/plugins/run_command.rs
+++ b/kdeconnect-core/src/plugins/run_command.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tracing::{info, warn};
 
+use crate::device::DeviceId;
+use crate::event::{ConnectionEvent, RemoteCommand};
 use crate::plugin_interface::Plugin;
 use crate::protocol::{PacketType, ProtocolPacket};
 
@@ -27,9 +29,8 @@ fn commands_config_path() -> std::path::PathBuf {
         .join("runcommand.json")
 }
 
-/// Load all locally defined commands (returns empty vec if file is missing).
-fn load_local_commands() -> Vec<LocalCommand> {
-    match std::fs::read_to_string(commands_config_path()) {
+async fn load_local_commands() -> Vec<LocalCommand> {
+    match tokio::fs::read_to_string(commands_config_path()).await {
         Ok(json) => serde_json::from_str(&json).unwrap_or_default(),
         Err(_) => vec![],
     }
@@ -79,17 +80,23 @@ impl Plugin for RunCommandRequest {
 
 impl RunCommand {
     /// Desktop received a command list from the phone (bidirectional support).
-    /// Not the primary use case — log and ignore for now.
     pub async fn received_packet(
         &self,
         device: &crate::device::Device,
-        _connection_tx: mpsc::UnboundedSender<crate::event::ConnectionEvent>,
+        connection_tx: mpsc::UnboundedSender<crate::event::ConnectionEvent>,
         _core_tx: mpsc::UnboundedSender<crate::event::CoreEvent>,
     ) {
+        let commands = parse_remote_commands(&self.command_list);
         info!(
-            "[runcommand] received command list from {} (canAddCommand={})",
-            device.device_id, self.can_add_command
+            "[runcommand] received {} remote command(s) from {} (canAddCommand={})",
+            commands.len(),
+            device.device_id,
+            self.can_add_command
         );
+        let _ = connection_tx.send(ConnectionEvent::RunCommandListReceived((
+            device.device_id.clone(),
+            commands,
+        )));
     }
 }
 
@@ -102,12 +109,9 @@ impl RunCommandRequest {
     ) {
         if let Some(key) = &self.key {
             // Phone is asking us to execute a local command by its UUID key.
-            let commands = load_local_commands();
+            let commands = load_local_commands().await;
             if let Some(cmd) = commands.iter().find(|c| c.id == *key) {
-                info!(
-                    "[runcommand] executing '{}': {}",
-                    cmd.name, cmd.command
-                );
+                info!("[runcommand] executing '{}': {}", cmd.name, cmd.command);
                 if let Err(e) = std::process::Command::new("sh")
                     .arg("-c")
                     .arg(&cmd.command)
@@ -138,10 +142,10 @@ impl RunCommandRequest {
 /// Called on device connect (kdeconnect-core/src/lib.rs) and when the phone
 /// requests the list via `requestCommandList: true`.
 pub async fn send_command_list(
-    device_id: &crate::device::DeviceId,
+    device_id: &DeviceId,
     core_tx: mpsc::UnboundedSender<crate::event::CoreEvent>,
 ) {
-    let commands = load_local_commands();
+    let commands = load_local_commands().await;
 
     // commandList must be a *JSON-encoded string*, not a nested object.
     // Format: "{\"<uuid>\": {\"name\": \"...\", \"command\": \"...\"}, ...}"
@@ -152,8 +156,8 @@ pub async fn send_command_list(
             serde_json::json!({ "name": cmd.name, "command": cmd.command }),
         );
     }
-    let command_list_str = serde_json::to_string(&serde_json::Value::Object(map))
-        .unwrap_or_else(|_| "{}".to_string());
+    let command_list_str =
+        serde_json::to_string(&serde_json::Value::Object(map)).unwrap_or_else(|_| "{}".to_string());
 
     info!(
         "[runcommand] sending {} command(s) to {}",
@@ -173,4 +177,55 @@ pub async fn send_command_list(
         device: device_id.clone(),
         packet,
     });
+}
+
+fn parse_remote_commands(command_list: &str) -> Vec<RemoteCommand> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(command_list) else {
+        warn!("[runcommand] received invalid commandList JSON");
+        return Vec::new();
+    };
+
+    let Some(map) = value.as_object() else {
+        warn!("[runcommand] commandList is not a JSON object");
+        return Vec::new();
+    };
+
+    map.iter()
+        .filter_map(|(key, value)| {
+            let name = value.get("name")?.as_str()?.to_string();
+            let command = value
+                .get("command")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            Some(RemoteCommand {
+                key: key.clone(),
+                name,
+                command,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_remote_commands;
+
+    #[test]
+    fn parses_remote_command_list_json_string() {
+        let commands = parse_remote_commands(
+            r#"{"abc":{"name":"Lock screen","command":"loginctl lock-session"}}"#,
+        );
+
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].key, "abc");
+        assert_eq!(commands[0].name, "Lock screen");
+        assert_eq!(commands[0].command, "loginctl lock-session");
+    }
+
+    #[test]
+    fn invalid_remote_command_list_is_empty() {
+        assert!(parse_remote_commands("not json").is_empty());
+        assert!(parse_remote_commands("[]").is_empty());
+    }
 }

--- a/kdeconnect-core/src/plugins/share.rs
+++ b/kdeconnect-core/src/plugins/share.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, str::FromStr};
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
@@ -39,22 +42,33 @@ impl ShareRequest {
             let pathbuf = PathBuf::from_str(file)?;
 
             if !pathbuf.exists() {
+                warn!("[share] skipping missing path: {}", pathbuf.display());
                 continue;
             }
 
-            let filename = pathbuf
+            let Some(filename) = pathbuf
                 .file_name()
-                .unwrap()
-                .to_str()
-                .expect("OsString conversion")
-                .to_string();
+                .and_then(|name| name.to_str())
+                .map(ToOwned::to_owned)
+            else {
+                warn!(
+                    "[share] skipping path without valid UTF-8 filename: {}",
+                    pathbuf.display()
+                );
+                continue;
+            };
+
+            let Some(path) = pathbuf.to_str().map(ToOwned::to_owned) else {
+                warn!("[share] skipping non-UTF-8 path: {}", pathbuf.display());
+                continue;
+            };
 
             let body = ShareRequestFile {
                 filename,
                 open: Some(false),
             };
 
-            requests.push((Self::File(body), pathbuf.to_str().unwrap().to_string()));
+            requests.push((Self::File(body), path));
         }
 
         Ok(requests)
@@ -63,10 +77,18 @@ impl ShareRequest {
     pub async fn receive_share(
         &self,
         device: &Device,
-        info: &PacketPayloadTransferInfo,
+        info: Option<&PacketPayloadTransferInfo>,
     ) -> anyhow::Result<()> {
         match self {
-            ShareRequest::File(f) => self.handle_file_request(f, device, info).await,
+            ShareRequest::File(f) => {
+                let Some(info) = info else {
+                    return Err(anyhow::anyhow!(
+                        "file share from {} did not include payload transfer info",
+                        device.name
+                    ));
+                };
+                self.handle_file_request(f, device, info).await
+            }
             ShareRequest::Text { text } => {
                 let text = text.clone();
                 tokio::task::spawn_blocking(move || {
@@ -138,6 +160,20 @@ impl ShareRequest {
 
         info!("[share] saved '{}' to {:?}", request.filename, dest);
 
+        if request.open.unwrap_or(false) {
+            let open_path = dest.clone();
+            tokio::task::spawn_blocking(move || {
+                let _ = std::process::Command::new("xdg-open")
+                    .arg(open_path)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .spawn();
+            })
+            .await
+            .ok();
+        }
+
         let dest_display = dest.display().to_string();
         let filename = request.filename.clone();
         tokio::task::spawn_blocking(move || {
@@ -154,31 +190,43 @@ impl ShareRequest {
     }
 }
 
-/// Returns a path that doesn't already exist by appending ` (N)` before the
-/// extension — e.g. `photo (1).jpg`, `photo (2).jpg`.
-fn unique_path(dir: &PathBuf, filename: &str) -> PathBuf {
-    let candidate = dir.join(filename);
+fn sanitize_filename(filename: &str) -> String {
+    let after_last_sep = filename.rsplit(['/', '\\']).next().unwrap_or(filename);
+    let sanitized: String = after_last_sep
+        .chars()
+        .filter(|c| !matches!(c, '/' | '\\' | '\0'))
+        .collect();
+    if sanitized.is_empty() || sanitized == "." || sanitized == ".." {
+        "download".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn unique_path(dir: &Path, filename: &str) -> PathBuf {
+    let filename = sanitize_filename(filename);
+    let candidate = dir.join(&filename);
     if !candidate.exists() {
         return candidate;
     }
 
-    let stem = PathBuf::from(filename)
+    let stem = PathBuf::from(&filename)
         .file_stem()
         .map(|s| s.to_string_lossy().into_owned())
-        .unwrap_or_else(|| filename.to_string());
-    let ext = PathBuf::from(filename)
+        .unwrap_or_else(|| filename.clone());
+    let ext = PathBuf::from(&filename)
         .extension()
         .map(|e| format!(".{}", e.to_string_lossy()))
         .unwrap_or_default();
 
-    for i in 1u32.. {
+    for i in 1u32..10000 {
         let candidate = dir.join(format!("{} ({}){}", stem, i, ext));
         if !candidate.exists() {
             return candidate;
         }
     }
 
-    dir.join(filename)
+    dir.join(format!("{}-{}{}", stem, uuid::Uuid::new_v4(), ext))
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -208,5 +256,80 @@ impl ShareRequest {
         );
 
         let _ = writer.send(packet);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_strips_directory_traversal() {
+        assert_eq!(
+            sanitize_filename("../../.ssh/authorized_keys"),
+            "authorized_keys"
+        );
+        assert_eq!(sanitize_filename("../../../etc/passwd"), "passwd");
+        assert_eq!(sanitize_filename("/etc/shadow"), "shadow");
+    }
+
+    #[test]
+    fn sanitize_strips_path_separators() {
+        assert_eq!(sanitize_filename("foo/bar/baz.txt"), "baz.txt");
+        assert_eq!(sanitize_filename("foo\\bar\\baz.txt"), "baz.txt");
+    }
+
+    #[test]
+    fn sanitize_handles_empty_and_dot_names() {
+        assert_eq!(sanitize_filename(""), "download");
+        assert_eq!(sanitize_filename("."), "download");
+        assert_eq!(sanitize_filename(".."), "download");
+        assert_eq!(sanitize_filename("/"), "download");
+        assert_eq!(sanitize_filename("///"), "download");
+    }
+
+    #[test]
+    fn sanitize_preserves_normal_filenames() {
+        assert_eq!(sanitize_filename("photo.jpg"), "photo.jpg");
+        assert_eq!(sanitize_filename("my file (1).txt"), "my file (1).txt");
+        assert_eq!(sanitize_filename("document.tar.gz"), "document.tar.gz");
+    }
+
+    #[test]
+    fn sanitize_handles_null_bytes() {
+        assert_eq!(sanitize_filename("evil\0name.txt"), "evilname.txt");
+    }
+
+    #[test]
+    fn unique_path_uses_sanitized_name() {
+        let dir = std::env::temp_dir();
+        let result = unique_path(&dir, "../../etc/passwd");
+        assert!(result.starts_with(&dir));
+        assert_eq!(result.file_name().unwrap().to_str().unwrap(), "passwd");
+    }
+
+    #[test]
+    fn unique_path_returns_base_if_not_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = unique_path(tmp.path(), "test.txt");
+        assert_eq!(result, tmp.path().join("test.txt"));
+    }
+
+    #[test]
+    fn unique_path_appends_counter_for_existing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("test.txt"), "").unwrap();
+        let result = unique_path(tmp.path(), "test.txt");
+        assert_eq!(result, tmp.path().join("test (1).txt"));
+    }
+
+    #[test]
+    fn unique_path_skips_existing_counters() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("test.txt"), "").unwrap();
+        std::fs::write(tmp.path().join("test (1).txt"), "").unwrap();
+        std::fs::write(tmp.path().join("test (2).txt"), "").unwrap();
+        let result = unique_path(tmp.path(), "test.txt");
+        assert_eq!(result, tmp.path().join("test (3).txt"));
     }
 }

--- a/kdeconnect-core/src/plugins/sms.rs
+++ b/kdeconnect-core/src/plugins/sms.rs
@@ -9,6 +9,8 @@ use crate::plugin_interface::Plugin;
 pub struct SmsMessages {
     pub messages: Vec<SmsMessage>,
     pub version: Option<i32>,
+    #[serde(skip)]
+    pub device_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -44,13 +46,19 @@ pub struct SmsAttachment {
 }
 
 impl SmsMessages {
-    pub async fn received_packet(&self, tx: mpsc::UnboundedSender<ConnectionEvent>) {
+    pub async fn received_packet(
+        &self,
+        device_id: String,
+        tx: mpsc::UnboundedSender<ConnectionEvent>,
+    ) {
         info!(
             "Received SMS messages packet with {} messages",
             self.messages.len()
         );
 
-        let event = ConnectionEvent::SmsMessages(self.clone());
+        let mut event_data = self.clone();
+        event_data.device_id = Some(device_id);
+        let event = ConnectionEvent::SmsMessages(event_data);
         let _ = tx.send(event);
     }
 }

--- a/kdeconnect-core/src/plugins/systemvolume.rs
+++ b/kdeconnect-core/src/plugins/systemvolume.rs
@@ -9,7 +9,10 @@ use libpulse_binding::{
     volume::{ChannelVolumes, Volume},
 };
 use serde::{Deserialize, Serialize};
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU64, Ordering},
+};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
@@ -72,6 +75,7 @@ enum PaMessage {
 #[derive(Clone)]
 struct PaConnection {
     tx: mpsc::UnboundedSender<PaMessage>,
+    generation: u64,
 }
 
 impl PaConnection {
@@ -83,6 +87,7 @@ impl PaConnection {
 // Global map: device_id → PA connection handle.
 static PA_CONNECTIONS: std::sync::LazyLock<Mutex<std::collections::HashMap<String, PaConnection>>> =
     std::sync::LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static PA_GENERATION: AtomicU64 = AtomicU64::new(1);
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -90,10 +95,18 @@ static PA_CONNECTIONS: std::sync::LazyLock<Mutex<std::collections::HashMap<Strin
 
 impl SystemVolumeRequest {
     pub async fn handle(&self, device: &Device, _core_tx: mpsc::UnboundedSender<CoreEvent>) {
-        info!("[systemvolume] handle called: request_sinks={:?} name={:?} volume={:?} muted={:?}",
-            self.request_sinks, self.name, self.volume, self.muted);
+        info!(
+            "[systemvolume] handle called: request_sinks={:?} name={:?} volume={:?} muted={:?}",
+            self.request_sinks, self.name, self.volume, self.muted
+        );
         let conn = {
-            let map = PA_CONNECTIONS.lock().unwrap();
+            let map = match PA_CONNECTIONS.lock() {
+                Ok(m) => m,
+                Err(_) => {
+                    warn!("[systemvolume] PA_CONNECTIONS mutex poisoned");
+                    return;
+                }
+            };
             map.get(&device.device_id.0).cloned()
         };
 
@@ -126,10 +139,17 @@ pub fn on_device_connect(device_id: DeviceId, core_tx: mpsc::UnboundedSender<Cor
     info!("[systemvolume] on_device_connect for {}", device_id.0);
 
     let (tx, rx) = mpsc::unbounded_channel::<PaMessage>();
-    let conn = PaConnection { tx };
+    let generation = PA_GENERATION.fetch_add(1, Ordering::Relaxed);
+    let conn = PaConnection { tx, generation };
 
     {
-        let mut map = PA_CONNECTIONS.lock().unwrap();
+        let mut map = match PA_CONNECTIONS.lock() {
+            Ok(m) => m,
+            Err(_) => {
+                warn!("[systemvolume] PA_CONNECTIONS mutex poisoned in on_device_connect");
+                return;
+            }
+        };
         // Drop the old sender — this closes the old thread's channel, causing it to exit cleanly.
         map.remove(&device_id.0);
         map.insert(device_id.0.clone(), conn);
@@ -138,10 +158,31 @@ pub fn on_device_connect(device_id: DeviceId, core_tx: mpsc::UnboundedSender<Cor
     let did = device_id.clone();
     std::thread::spawn(move || {
         pa_thread(did.clone(), core_tx, rx);
-        let mut map = PA_CONNECTIONS.lock().unwrap();
-        map.remove(&did.0);
+        if let Ok(mut map) = PA_CONNECTIONS.lock()
+            && map
+                .get(&did.0)
+                .map(|conn| conn.generation == generation)
+                .unwrap_or(false)
+        {
+            map.remove(&did.0);
+        }
         info!("[systemvolume] PA thread exited for {}", did.0);
     });
+}
+
+pub fn on_device_disconnect(device_id: &DeviceId) {
+    let conn = match PA_CONNECTIONS.lock() {
+        Ok(mut map) => map.remove(&device_id.0),
+        Err(_) => {
+            warn!("[systemvolume] PA_CONNECTIONS mutex poisoned in on_device_disconnect");
+            None
+        }
+    };
+
+    if let Some(conn) = conn {
+        conn.send(PaMessage::Quit);
+        info!("[systemvolume] stopped PA thread for {}", device_id.0);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -240,11 +281,11 @@ fn pa_thread(
         // Subscribe to sink changes — signal ourselves via the message channel.
         let did_sub = device_id.clone();
         context.set_subscribe_callback(Some(Box::new(move |facility, _op, _index| {
-            if facility == Some(Facility::Sink) {
-                let map = PA_CONNECTIONS.lock().unwrap();
-                if let Some(conn) = map.get(&did_sub.0) {
-                    conn.send(PaMessage::GetSinks);
-                }
+            if facility == Some(Facility::Sink)
+                && let Ok(map) = PA_CONNECTIONS.lock()
+                && let Some(conn) = map.get(&did_sub.0)
+            {
+                conn.send(PaMessage::GetSinks);
             }
         })));
         context.subscribe(InterestMaskSet::SINK, |_| {});
@@ -308,7 +349,7 @@ fn pa_thread(
                 }
                 Err(mpsc::error::TryRecvError::Empty) => {
                     // Nothing pending — yield briefly.
-                    std::thread::sleep(std::time::Duration::from_millis(10));
+                    std::thread::sleep(std::time::Duration::from_millis(250));
                 }
                 Err(mpsc::error::TryRecvError::Disconnected) => {
                     info!(
@@ -336,9 +377,9 @@ fn enumerate_sinks(mainloop: &mut Mainloop, context: &Context) -> Option<Vec<Sin
     mainloop.lock();
     let introspect = context.introspect();
     let op = introspect.get_server_info(move |info| {
-        *default_sink_cb.lock().unwrap() = info.default_sink_name
-            .as_deref()
-            .map(|s| s.to_string());
+        if let Ok(mut guard) = default_sink_cb.lock() {
+            *guard = info.default_sink_name.as_deref().map(|s| s.to_string());
+        }
     });
 
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
@@ -353,7 +394,13 @@ fn enumerate_sinks(mainloop: &mut Mainloop, context: &Context) -> Option<Vec<Sin
     }
     mainloop.unlock();
 
-    let default_name = default_sink.lock().unwrap().clone();
+    let default_name = match default_sink.lock() {
+        Ok(g) => g.clone(),
+        Err(_) => {
+            warn!("[systemvolume] default_sink mutex poisoned");
+            return None;
+        }
+    };
     info!("[systemvolume] default sink: {:?}", default_name);
 
     // Now enumerate sinks.
@@ -363,10 +410,11 @@ fn enumerate_sinks(mainloop: &mut Mainloop, context: &Context) -> Option<Vec<Sin
 
     mainloop.lock();
     let op = introspect.get_sink_info_list(move |result| {
-        if let ListResult::Item(info) = result {
-            if let Some(sink) = pa_sink_to_info(info, &default_name_cb) {
-                sinks_cb.lock().unwrap().push(sink);
-            }
+        if let ListResult::Item(info) = result
+            && let Some(sink) = pa_sink_to_info(info, &default_name_cb)
+            && let Ok(mut guard) = sinks_cb.lock()
+        {
+            guard.push(sink);
         }
     });
 
@@ -393,27 +441,40 @@ fn set_volume(mainloop: &mut Mainloop, context: &Context, name: &str, volume: u3
     mainloop.lock();
     let mut introspect = context.introspect();
     let op = introspect.get_sink_info_by_name(name, move |result| {
-        if let ListResult::Item(info) = result {
-            *channels_cb.lock().unwrap() = info.channel_map.len() as u8;
+        if let ListResult::Item(info) = result
+            && let Ok(mut guard) = channels_cb.lock()
+        {
+            *guard = info.channel_map.len();
         }
     });
 
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
     while op.get_state() == libpulse_binding::operation::State::Running {
-        if std::time::Instant::now() > deadline { break; }
+        if std::time::Instant::now() > deadline {
+            break;
+        }
         mainloop.unlock();
         std::thread::sleep(std::time::Duration::from_millis(50));
         mainloop.lock();
     }
 
-    let ch = *channels.lock().unwrap();
+    let ch = match channels.lock() {
+        Ok(g) => *g,
+        Err(_) => {
+            warn!("[systemvolume] channels mutex poisoned");
+            mainloop.unlock();
+            return;
+        }
+    };
     let mut cvol = ChannelVolumes::default();
     cvol.set(ch, Volume(volume));
 
     let op = introspect.set_sink_volume_by_name(name, &cvol, None::<Box<dyn FnMut(bool)>>);
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
     while op.get_state() == libpulse_binding::operation::State::Running {
-        if std::time::Instant::now() > deadline { break; }
+        if std::time::Instant::now() > deadline {
+            break;
+        }
         mainloop.unlock();
         std::thread::sleep(std::time::Duration::from_millis(50));
         mainloop.lock();
@@ -427,7 +488,9 @@ fn set_mute(mainloop: &mut Mainloop, context: &Context, name: &str, muted: bool)
     let op = introspect.set_sink_mute_by_name(name, muted, None::<Box<dyn FnMut(bool)>>);
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
     while op.get_state() == libpulse_binding::operation::State::Running {
-        if std::time::Instant::now() > deadline { break; }
+        if std::time::Instant::now() > deadline {
+            break;
+        }
         mainloop.unlock();
         std::thread::sleep(std::time::Duration::from_millis(50));
         mainloop.lock();
@@ -443,7 +506,13 @@ fn pa_sink_to_info(info: &PASinkInfo, default_sink: &Option<String>) -> Option<S
     let name = info.name.as_deref()?.to_string();
     let description = info.description.as_deref().unwrap_or(&name).to_string();
     let enabled = default_sink.as_deref() == Some(name.as_str());
-    info!("[systemvolume] sink '{}' volume={} max={} enabled={}", name, info.volume.avg().0, MAX_VOLUME, enabled);
+    info!(
+        "[systemvolume] sink '{}' volume={} max={} enabled={}",
+        name,
+        info.volume.avg().0,
+        MAX_VOLUME,
+        enabled
+    );
     Some(SinkInfo {
         name,
         description,

--- a/kdeconnect-core/src/plugins/telephony.rs
+++ b/kdeconnect-core/src/plugins/telephony.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
-use base64::{engine::general_purpose, Engine as _};
 use crate::plugins::mpris;
+use base64::{Engine as _, engine::general_purpose};
+use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tracing::info;
 
@@ -100,10 +100,10 @@ impl TelephonyPacket {
 
         // Pause desktop players before showing the notification.
         // missedCall arrives after the fact so we skip pausing for that.
-        if event != "missedCall" {
-            if let Some(tx) = mpris::telephony_call_signal() {
-                let _ = tx.send(true);
-            }
+        if event != "missedCall"
+            && let Some(tx) = mpris::telephony_call_signal()
+        {
+            let _ = tx.send(true);
         }
 
         let thumbnail_path = self.phone_thumbnail.as_deref().and_then(|b64| {
@@ -120,7 +120,7 @@ impl TelephonyPacket {
             Some(path)
         });
 
-        let _ = tokio::task::spawn_blocking(move || {
+        tokio::task::spawn_blocking(move || {
             let mut notif = notify_rust::Notification::new();
             notif
                 .appname("KDE Connect")
@@ -128,13 +128,12 @@ impl TelephonyPacket {
                 .body(&body)
                 .timeout(notify_rust::Timeout::Milliseconds(10_000));
             if let Some(path) = thumbnail_path {
-                notif.icon(&path.to_string_lossy().into_owned());
+                notif.icon(&path.to_string_lossy());
             } else {
                 notif.icon("call-start-symbolic");
             }
             notif.show().ok();
-        })
-        .await;
+        });
     }
 
     /// Send a kdeconnect.telephony.request_mute to silence the phone's ringer.
@@ -144,5 +143,47 @@ impl TelephonyPacket {
             device: device.device_id.clone(),
             packet,
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::{Device, DeviceId};
+    use std::time::Duration;
+
+    #[test]
+    fn received_packet_returns_immediately_without_blocking() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let passed = rt.block_on(async {
+            let pkt = TelephonyPacket {
+                event: Some("ringing".to_string()),
+                contact_name: Some("Test Caller".to_string()),
+                ..Default::default()
+            };
+            let device = Device {
+                device_id: DeviceId("test-telephony-nonblock".into()),
+                ..Default::default()
+            };
+            let (core_tx, _core_rx) = tokio::sync::mpsc::unbounded_channel();
+
+            tokio::time::timeout(
+                Duration::from_millis(500),
+                pkt.received_packet(&device, core_tx),
+            )
+            .await
+            .is_ok()
+        });
+
+        rt.shutdown_background();
+
+        assert!(
+            passed,
+            "telephony received_packet must return immediately without blocking on notification"
+        );
     }
 }

--- a/kdeconnect-core/src/protocol.rs
+++ b/kdeconnect-core/src/protocol.rs
@@ -11,6 +11,46 @@ use tokio::{fs::File, io::AsyncRead};
 
 pub const PROTOCOL_VERSION: usize = 8;
 
+fn deserialize_packet_id<'de, D>(deserializer: D) -> Result<Option<u128>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Option::<Value>::deserialize(deserializer)? {
+        Some(Value::Number(id)) => id
+            .as_u64()
+            .map(|id| Some(id as u128))
+            .ok_or_else(|| serde::de::Error::custom("packet id must be an unsigned integer")),
+        Some(Value::String(id)) => id
+            .parse::<u128>()
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+        None => Ok(None),
+        Some(_) => Err(serde::de::Error::custom(
+            "packet id must be a number or numeric string",
+        )),
+    }
+}
+
+fn deserialize_optional_usize<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Option::<Value>::deserialize(deserializer)? {
+        Some(Value::Number(id)) => id
+            .as_u64()
+            .map(|id| Some(id as usize))
+            .ok_or_else(|| serde::de::Error::custom("value must be an unsigned integer")),
+        Some(Value::String(id)) => id
+            .parse::<usize>()
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+        None => Ok(None),
+        Some(_) => Err(serde::de::Error::custom(
+            "value must be a number or numeric string",
+        )),
+    }
+}
+
 fn serialize_packet_type<S>(pt: &PacketType, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
@@ -27,7 +67,7 @@ where
     Ok(PacketType::from(s))
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum PacketType {
     Battery,
     BatteryRequest,
@@ -35,6 +75,8 @@ pub enum PacketType {
     ClipboardConnect,
     ConnectivityReport,
     ConnectivityReportRequest,
+    Digitizer,
+    DigitizerSession,
     ContactsRequestAllUidsTimestamps,
     ContactsRequestVcardsByUid,
     ContactsResponseUidsTimestamps,
@@ -85,6 +127,8 @@ impl From<String> for PacketType {
             "kdeconnect.clipboard.connect" => PacketType::ClipboardConnect,
             "kdeconnect.connectivity_report" => PacketType::ConnectivityReport,
             "kdeconnect.connectivity_report.request" => PacketType::ConnectivityReportRequest,
+            "kdeconnect.digitizer" => PacketType::Digitizer,
+            "kdeconnect.digitizer.session" => PacketType::DigitizerSession,
             "kdeconnect.contacts.request_all_uids_timestamps" => {
                 PacketType::ContactsRequestAllUidsTimestamps
             }
@@ -92,6 +136,7 @@ impl From<String> for PacketType {
             | "kdeconnect.contacts.response_all_uids_timestamps" => {
                 PacketType::ContactsResponseUidsTimestamps
             }
+            "kdeconnect.contacts.request_vcards_by_uid" => PacketType::ContactsRequestVcardsByUid,
             "kdeconnect.contacts.response_vcards" => PacketType::ContactsResponseVcards,
             "kdeconnect.findmyphone.request" => PacketType::FindMyPhoneRequest,
             "kdeconnect.lock" => PacketType::Lock,
@@ -144,6 +189,8 @@ impl Display for PacketType {
             PacketType::ConnectivityReportRequest => {
                 write!(f, "kdeconnect.connectivity_report.request")
             }
+            PacketType::Digitizer => write!(f, "kdeconnect.digitizer"),
+            PacketType::DigitizerSession => write!(f, "kdeconnect.digitizer.session"),
             PacketType::ContactsRequestAllUidsTimestamps => {
                 write!(f, "kdeconnect.contacts.request_all_uids_timestamps")
             }
@@ -160,7 +207,7 @@ impl Display for PacketType {
             PacketType::Lock => write!(f, "kdeconnect.lock"),
             PacketType::LockRequest => write!(f, "kdeconnect.lock.request"),
             PacketType::MousePadEcho => write!(f, "kdeconnect.mousepad.echo"),
-            PacketType::MousePadKeyboardState => write!(f, "kdeconnect.mousepad.keyboard_state"),
+            PacketType::MousePadKeyboardState => write!(f, "kdeconnect.mousepad.keyboardstate"),
             PacketType::MousePadRequest => write!(f, "kdeconnect.mousepad.request"),
             PacketType::Mpris => write!(f, "kdeconnect.mpris"),
             PacketType::MprisRequest => write!(f, "kdeconnect.mpris.request"),
@@ -199,6 +246,7 @@ impl Display for PacketType {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ProtocolPacket {
+    #[serde(default, deserialize_with = "deserialize_packet_id")]
     pub id: Option<u128>,
     #[serde(rename = "type")]
     #[serde(
@@ -279,14 +327,103 @@ impl ProtocolPacket {
     }
 
     pub fn from_raw(raw: &[u8]) -> anyhow::Result<Self> {
-        let pkt: ProtocolPacket =
-            serde_json::from_slice(raw).expect("Failed to parse ProtocolPacket from raw data");
-        Ok(pkt)
+        Ok(serde_json::from_slice(raw)?)
     }
 
     pub fn as_raw(&self) -> anyhow::Result<Vec<u8>> {
-        let str = serde_json::to_string(self)?;
-        Ok(format!("{}\n", str).as_bytes().to_vec())
+        let mut buf = serde_json::to_vec(self)?;
+        buf.push(b'\n');
+        Ok(buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn packet_type_round_trips_known_protocol_names() {
+        let cases = [
+            (
+                "kdeconnect.contacts.request_vcards_by_uid",
+                PacketType::ContactsRequestVcardsByUid,
+            ),
+            (
+                "kdeconnect.mousepad.keyboardstate",
+                PacketType::MousePadKeyboardState,
+            ),
+        ];
+
+        for (wire_name, packet_type) in cases {
+            assert!(matches!(
+                PacketType::from(wire_name.to_string()),
+                pt if std::mem::discriminant(&pt) == std::mem::discriminant(&packet_type)
+            ));
+            assert_eq!(packet_type.to_string(), wire_name);
+        }
+    }
+
+    #[test]
+    fn from_raw_returns_error_for_invalid_json() {
+        assert!(ProtocolPacket::from_raw(b"not json\n").is_err());
+    }
+
+    #[test]
+    fn packet_id_accepts_kdeconnect_string_timestamp() {
+        let decoded = ProtocolPacket::from_raw(
+            br#"{"id":"1712345678901","type":"kdeconnect.ping","body":{}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(decoded.id, Some(1_712_345_678_901));
+        assert!(matches!(decoded.packet_type, PacketType::Ping));
+    }
+
+    #[test]
+    fn packet_serialization_uses_newline_delimited_json() {
+        let packet = ProtocolPacket::new(PacketType::Ping, json!({"message": "hello"}));
+        let raw = packet.as_raw().unwrap();
+        assert_eq!(raw.last(), Some(&b'\n'));
+        let decoded = ProtocolPacket::from_raw(&raw).unwrap();
+        assert!(matches!(decoded.packet_type, PacketType::Ping));
+        assert_eq!(decoded.body["message"], "hello");
+    }
+
+    #[test]
+    fn identity_accepts_android_string_target_protocol_version() {
+        let identity: Identity = serde_json::from_value(json!({
+            "deviceId": "abcdef1234567890abcdef1234567890",
+            "deviceName": "Phone",
+            "deviceType": "phone",
+            "incomingCapabilities": [],
+            "outgoingCapabilities": [],
+            "protocolVersion": 8,
+            "targetDeviceId": "0123456789abcdef0123456789abcdef",
+            "targetProtocolVersion": "8"
+        }))
+        .unwrap();
+
+        assert_eq!(identity.target_protocol_version, Some(8));
+        assert_eq!(
+            identity.target_device_id.as_deref(),
+            Some("0123456789abcdef0123456789abcdef")
+        );
+    }
+
+    #[test]
+    fn pair_packets_only_timestamp_new_requests() {
+        let request = Pair::request();
+        assert!(request.pair);
+        assert!(request.timestamp.is_some());
+
+        let accept = Pair::accept();
+        assert!(accept.pair);
+        assert!(accept.timestamp.is_none());
+
+        let reject = Pair::reject();
+        assert!(!reject.pair);
+        assert!(reject.timestamp.is_none());
     }
 }
 
@@ -300,6 +437,14 @@ pub struct Identity {
     pub outgoing_capabilities: Vec<String>,
     pub protocol_version: usize,
     pub tcp_port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_device_id: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_usize",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub target_protocol_version: Option<usize>,
 }
 
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
@@ -310,21 +455,38 @@ pub struct Pair {
 }
 
 impl Pair {
-    pub fn new(response: bool) -> Self {
-        if response {
-            let timestamp = Some(
-                SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs(),
-            );
-            return Pair {
-                pair: true,
-                timestamp,
-            };
-        }
+    /// Backward-compatible constructor used by upstream callers.
+    #[allow(dead_code)]
+    pub fn new(pair: bool) -> Self {
         Pair {
-            pair: response,
+            pair,
+            timestamp: None,
+        }
+    }
+
+    pub fn request() -> Self {
+        let timestamp = Some(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        );
+        Pair {
+            pair: true,
+            timestamp,
+        }
+    }
+
+    pub fn accept() -> Self {
+        Pair {
+            pair: true,
+            timestamp: None,
+        }
+    }
+
+    pub fn reject() -> Self {
+        Pair {
+            pair: false,
             timestamp: None,
         }
     }
@@ -355,7 +517,7 @@ impl DeviceFile<File> {
         let metadata = file.metadata().await?;
         Ok(DeviceFile {
             buf: file,
-            size: metadata.size().try_into().map_err(std::io::Error::other)?,
+            size: metadata.size(),
         })
     }
 

--- a/kdeconnect-core/src/transport.rs
+++ b/kdeconnect-core/src/transport.rs
@@ -1,32 +1,51 @@
 use std::{
-    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    collections::HashMap,
+    net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
     path::PathBuf,
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use rustls::pki_types::ServerName;
 use socket2::TcpKeepalive;
 use tokio::{
-    io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt, BufReader, split},
+    io::{
+        AsyncBufReadExt as _, AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt, BufReader,
+        split,
+    },
     net::{TcpListener, TcpStream, UdpSocket},
-    sync::{Mutex, mpsc},
+    sync::{Mutex, mpsc, watch},
     time::MissedTickBehavior,
 };
-use tokio_rustls::TlsAcceptor;
+use tokio_rustls::{TlsAcceptor, TlsConnector};
 use tracing::{debug, error, info, warn};
 
 use crate::{
     GLOBAL_CONFIG,
-    device::DeviceId,
+    device::{Device, DeviceId, PairState},
     plugin_config,
     protocol::{Identity, PacketType, ProtocolPacket},
 };
+use std::sync::Mutex as StdMutex;
+
+use once_cell::sync::Lazy;
 
 pub const DEFAULT_DISCOVERY_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Application-level keepalive interval — sends a bare newline to keep the
+/// TCP connection from going idle long enough to trigger OS keepalive probes
+/// (which Android Doze often ignores, causing spurious disconnects).
+/// Bare newlines are silently skipped by all KDE Connect readers and never
+/// surfaced to users.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+const TLS_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(250);
+const MAX_IDENTITY_PACKET_SIZE: usize = 8192;
+const MIN_DISCOVERY_CONNECTION_INTERVAL: Duration = Duration::from_millis(500);
+const IDENTITY_BURST_COUNT: usize = 2;
+const IDENTITY_BURST_DELAY: Duration = Duration::from_millis(250);
 
 pub const DEFAULT_LISTEN_PORT: u16 = 1716;
 pub const DEFAULT_LISTEN_ADDR: SocketAddr = SocketAddr::V4(SocketAddrV4::new(
@@ -42,6 +61,52 @@ pub const BROADCAST_ADDR: SocketAddr =
 /// incorrectly wiping a newer live connection out of `writer_map`.
 static CONN_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// Extra per-connection metadata stored outside TransportEvent so the enum
+/// stays compatible with upstream's shape (no `device_type`, `shutdown_tx`,
+/// `peer_certificate`, etc. in the event fields).  Core reads this map after
+/// consuming a `NewConnection` / `IncomingPacket` / … event.
+#[derive(Debug, Clone)]
+pub(crate) struct ConnMetadata {
+    pub device_type: String,
+    pub incoming_capabilities: Vec<String>,
+    pub outgoing_capabilities: Vec<String>,
+    pub protocol_version: usize,
+    pub pairing_timestamp: u64,
+    pub peer_certificate: Vec<u8>,
+    pub shutdown_tx: watch::Sender<bool>,
+    /// conn_id of the *next* IncomingPacket (set by the reader task before
+    /// sending the event so the wildcard `IncomingPacket` arm in core can
+    /// look it up).
+    pub incoming_conn_id: u64,
+}
+
+pub(crate) static CONN_METADATA: Lazy<StdMutex<HashMap<DeviceId, ConnMetadata>>> =
+    Lazy::new(|| StdMutex::new(HashMap::new()));
+
+/// Pop and return the metadata for a device, if present.
+pub(crate) fn take_conn_metadata(id: &DeviceId) -> Option<ConnMetadata> {
+    CONN_METADATA.lock().ok()?.get(id).cloned()
+}
+
+#[derive(Default)]
+pub(crate) struct ConnectionRateLimiter {
+    by_device: Mutex<HashMap<DeviceId, Instant>>,
+}
+
+impl ConnectionRateLimiter {
+    pub(crate) async fn allow_device_connection(&self, id: &DeviceId) -> bool {
+        let now = Instant::now();
+        let mut guard = self.by_device.lock().await;
+        if let Some(last_seen) = guard.get(id)
+            && now.duration_since(*last_seen) < MIN_DISCOVERY_CONNECTION_INTERVAL
+        {
+            return false;
+        }
+        guard.insert(id.clone(), now);
+        true
+    }
+}
+
 #[derive(Debug)]
 pub enum TransportEvent {
     IncomingPacket {
@@ -54,22 +119,30 @@ pub enum TransportEvent {
         id: DeviceId,
         name: String,
         write_tx: mpsc::UnboundedSender<ProtocolPacket>,
-        /// Unique ID for this connection instance.
         conn_id: u64,
     },
-    /// Emitted when the reader loop ends (peer closed / broken pipe).
-    /// `conn_id` must match the stored value for this device before core
-    /// removes the writer_map entry; a mismatch means a newer connection
-    /// has already replaced this one.
-    Disconnected { id: DeviceId, conn_id: u64 },
+    Disconnected {
+        id: DeviceId,
+        conn_id: u64,
+    },
+    /// Emitted when a paired device presents a mismatched TLS certificate.
+    PairTrustFailed {
+        id: DeviceId,
+    },
+    /// Emitted by the writer task when a packet could not be sent to the peer.
+    PacketSendFailed {
+        id: DeviceId,
+        packet_type: PacketType,
+        conn_id: u64,
+    },
 }
 
-/// Enable TCP keepalive so the OS detects a dead connection within ~60s
-/// (30s idle + 3 × 10s probes) rather than waiting indefinitely.
+/// Enable TCP keepalive so the OS detects a dead connection within ~25s
+/// (10s idle + 3 × 5s probes) rather than waiting indefinitely.
 fn apply_keepalive(stream: &TcpStream) {
     let keepalive = TcpKeepalive::new()
-        .with_time(Duration::from_secs(30))
-        .with_interval(Duration::from_secs(10))
+        .with_time(Duration::from_secs(10))
+        .with_interval(Duration::from_secs(5))
         .with_retries(3);
     let sock_ref = socket2::SockRef::from(stream);
     if let Err(e) = sock_ref.set_tcp_keepalive(&keepalive) {
@@ -77,26 +150,163 @@ fn apply_keepalive(stream: &TcpStream) {
     }
 }
 
+fn is_private_kdeconnect_addr(addr: IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(addr) => {
+            let octets = addr.octets();
+            let is_cgnat = octets[0] == 100 && (octets[1] & 0b1100_0000) == 0b0100_0000;
+            addr.is_private() || addr.is_link_local() || addr.is_loopback() || is_cgnat
+        }
+        IpAddr::V6(addr) => {
+            addr.is_unique_local() || addr.is_unicast_link_local() || addr.is_loopback()
+        }
+    }
+}
+
+async fn read_line_bounded<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    max_len: usize,
+) -> anyhow::Result<String> {
+    let mut raw = Vec::new();
+    let mut byte = [0u8; 1];
+    loop {
+        match reader.read(&mut byte).await? {
+            0 => return Err(anyhow::anyhow!("EOF reading identity")),
+            1 => {
+                raw.push(byte[0]);
+                if byte[0] == b'\n' {
+                    break;
+                }
+                if raw.len() > max_len {
+                    return Err(anyhow::anyhow!("identity line too long"));
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+    Ok(String::from_utf8_lossy(&raw).into_owned())
+}
+
+fn validate_identity_target(
+    peer_identity: &Identity,
+    local_identity: &Identity,
+) -> anyhow::Result<()> {
+    if let Some(target_device_id) = peer_identity.target_device_id.as_deref()
+        && target_device_id != local_identity.device_id
+    {
+        return Err(anyhow::anyhow!(
+            "received connection request for different target device {}",
+            target_device_id
+        ));
+    }
+
+    if let Some(target_protocol_version) = peer_identity.target_protocol_version
+        && target_protocol_version != local_identity.protocol_version
+    {
+        return Err(anyhow::anyhow!(
+            "received connection request for protocol {}, local protocol is {}",
+            target_protocol_version,
+            local_identity.protocol_version
+        ));
+    }
+
+    Ok(())
+}
+
+fn targeted_identity(
+    base: &Identity,
+    target_device_id: &str,
+    target_protocol_version: usize,
+) -> Identity {
+    let mut identity = base.clone();
+    identity.target_device_id = Some(target_device_id.to_string());
+    identity.target_protocol_version = Some(target_protocol_version);
+    identity
+}
+
+async fn write_identity_packet<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    identity: &Identity,
+) -> anyhow::Result<()> {
+    let raw =
+        ProtocolPacket::new(PacketType::Identity, serde_json::to_value(identity)?).as_raw()?;
+    writer.write_all(&raw).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+async fn exchange_secure_identity<S>(
+    stream: &mut S,
+    expected_device_id: &str,
+    expected_protocol_version: usize,
+    local_identity: &Identity,
+) -> anyhow::Result<Identity>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    write_identity_packet(stream, local_identity).await?;
+
+    let line = tokio::time::timeout(
+        Duration::from_secs(5),
+        read_line_bounded(stream, MAX_IDENTITY_PACKET_SIZE),
+    )
+    .await??;
+    let packet = serde_json::from_str::<ProtocolPacket>(&line)?;
+    if !matches!(packet.packet_type, PacketType::Identity) {
+        return Err(anyhow::anyhow!(
+            "expected secure identity packet, received {:?}",
+            packet.packet_type
+        ));
+    }
+
+    let identity = serde_json::from_value::<Identity>(packet.body)?;
+    crate::device::validate_device_id(&identity.device_id)?;
+    if identity.device_id != expected_device_id {
+        return Err(anyhow::anyhow!(
+            "device ID changed during TLS handshake: {} -> {}",
+            expected_device_id,
+            identity.device_id
+        ));
+    }
+    if identity.protocol_version != expected_protocol_version {
+        return Err(anyhow::anyhow!(
+            "protocol version changed during TLS handshake: {} -> {}",
+            expected_protocol_version,
+            identity.protocol_version
+        ));
+    }
+
+    Ok(identity)
+}
+
 pub struct TcpTransport {
     listen_addr: SocketAddr,
     event_tx: mpsc::UnboundedSender<TransportEvent>,
     identity: Arc<Identity>,
+    client_config: Arc<rustls::ClientConfig>,
     server_config: Arc<rustls::ServerConfig>,
+    rate_limiter: Arc<ConnectionRateLimiter>,
 }
 
 impl TcpTransport {
-    pub fn new(event_tx: &mpsc::UnboundedSender<TransportEvent>) -> Self {
+    pub fn new(
+        event_tx: &mpsc::UnboundedSender<TransportEvent>,
+        rate_limiter: Arc<ConnectionRateLimiter>,
+    ) -> Self {
         let config = GLOBAL_CONFIG.get().unwrap();
         let listen_addr = config.listen_addr;
         let event_tx = event_tx.clone();
         let identity = Arc::new(config.identity.clone());
+        let client_config = config.key_store.client_config.clone();
         let server_config = config.key_store.server_config.clone();
 
         Self {
             listen_addr,
             event_tx,
             identity,
+            client_config,
             server_config,
+            rate_limiter,
         }
     }
 
@@ -114,158 +324,32 @@ impl TcpTransport {
         info!("TCP listener bound to {}", self.listen_addr);
 
         loop {
-            let event_tx = self.event_tx.clone();
-            let identity = self.identity.clone();
-
             match listener.accept().await {
-                Ok((mut stream, peer)) => {
+                Ok((stream, peer)) => {
                     info!(peer = ?peer, "[tcp] new connection");
                     apply_keepalive(&stream);
 
-                    // Step 1: read phone's pre-TLS identity.
-                    // Read byte-by-byte to avoid BufReader consuming TLS ClientHello
-                    // bytes into its internal buffer, which would cause "tls handshake eof".
-                    debug!(peer = ?peer, "[tcp] step 1: reading pre-TLS identity");
-                    let buffer = {
-                        let mut raw = Vec::new();
-                        let mut byte = [0u8; 1];
-                        loop {
-                            match stream.read(&mut byte).await {
-                                Ok(0) => {
-                                    warn!(peer = ?peer, "[tcp] EOF reading identity");
-                                    break;
-                                }
-                                Ok(_) => {
-                                    raw.push(byte[0]);
-                                    if byte[0] == b'\n' { break; }
-                                    if raw.len() > 65536 {
-                                        warn!(peer = ?peer, "[tcp] identity line too long");
-                                        break;
-                                    }
-                                }
-                                Err(e) => {
-                                    warn!(peer = ?peer, "[tcp] failed to read identity line: {}", e);
-                                    break;
-                                }
-                            }
-                        }
-                        String::from_utf8_lossy(&raw).into_owned()
-                    };
-                    debug!(peer = ?peer, "[tcp] step 1: read {} bytes", buffer.len());
+                    let event_tx = self.event_tx.clone();
+                    let identity = self.identity.clone();
+                    let client_config = self.client_config.clone();
+                    let server_config = self.server_config.clone();
+                    let rate_limiter = self.rate_limiter.clone();
 
-                    let identity = identity.clone();
-
-                    let packet = match serde_json::from_str::<ProtocolPacket>(&buffer) {
-                        Ok(p) => p,
-                        Err(e) => {
-                            warn!(peer = ?peer, "[tcp] failed to parse identity packet: {}", e);
-                            continue;
-                        }
-                    };
-                    let peer_identity = match serde_json::from_value::<Identity>(packet.body) {
-                        Ok(i) => i,
-                        Err(e) => {
-                            warn!(peer = ?peer, "[tcp] failed to parse identity body: {}", e);
-                            // Complete the TLS handshake gracefully so the phone doesn't see
-                            // an abrupt TCP drop and retry aggressively causing connection churn.
-                            match TlsAcceptor::from(self.server_config.clone())
-                                .accept(stream)
-                                .await
-                            {
-                                Ok(mut tls_stream) => {
-                                    let _ = tls_stream.shutdown().await;
-                                }
-                                Err(tls_e) => {
-                                    warn!(peer = ?peer, "[tcp] TLS cleanup after identity error failed: {}", tls_e);
-                                }
-                            }
-                            continue;
-                        }
-                    };
-
-                    let name = peer_identity.device_name.clone();
-                    let id = peer_identity.device_id.clone();
-                    info!(peer = ?peer, device_id = ?id, device_name = name, "[tcp] identified peer");
-
-                    if identity.device_id == peer_identity.device_id {
-                        warn!(peer = ?peer, device_id = ?id, "skipping the same device");
-                        continue;
-                    }
-
-                    // Step 2: send our identity back pre-TLS
-                    debug!(peer = ?peer, "[tcp] step 2: sending our pre-TLS identity");
-                    let our_identity = ProtocolPacket::new(
-                        PacketType::Identity,
-                        serde_json::to_value(&*self.identity).unwrap(),
-                    )
-                    .as_raw()
-                    .expect("Failed to serialize identity packet");
-                    if let Err(e) = stream.write_all(our_identity.as_slice()).await {
-                        warn!(peer = ?peer, "[tcp] failed to send pre-TLS identity: {}", e);
-                        continue;
-                    }
-                    let _ = stream.flush().await;
-                    debug!(peer = ?peer, "[tcp] step 2: pre-TLS identity sent");
-
-                    // Step 3: TLS handshake — we are the server (phone connected to us)
-                    debug!(peer = ?peer, "[tcp] step 3: starting TLS accept (we are server)");
-                    let mut tls_stream = match TlsAcceptor::from(self.server_config.clone())
-                        .accept(stream)
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_incoming_tcp(
+                            stream,
+                            peer,
+                            event_tx,
+                            identity,
+                            client_config,
+                            server_config,
+                            rate_limiter,
+                        )
                         .await
-                    {
-                        Ok(s) => s,
-                        Err(e) => {
-                            warn!(peer = ?peer, "[tcp] TLS accept failed: {}", e);
-                            continue;
+                        {
+                            warn!(peer = ?peer, "[tcp] connection handler failed: {}", e);
                         }
-                    };
-                    info!(peer = ?peer, device_id = ?id, "[tcp] step 3: TLS established");
-
-                    // Step 4: send our identity post-TLS for plugin negotiation.
-                    // Filter capabilities based on per-device disabled plugins so
-                    // the phone immediately knows which packet types to stop sending.
-                    debug!(peer = ?peer, "[tcp] step 4: sending post-TLS identity");
-                    let filtered = filtered_identity_for_device(&id).await;
-                    let post_tls_identity = ProtocolPacket::new(
-                        PacketType::Identity,
-                        serde_json::to_value(&filtered).unwrap(),
-                    )
-                    .as_raw()
-                    .expect("Failed to serialize identity packet");
-                    if let Err(e) = tls_stream.write_all(post_tls_identity.as_slice()).await {
-                        warn!(peer = ?peer, "[tcp] failed to send post-TLS identity: {}", e);
-                        continue;
-                    }
-                    let _ = tls_stream.flush().await;
-                    debug!(peer = ?peer, "[tcp] step 4: post-TLS identity sent");
-
-                    let (reader, writer) = split(tls_stream);
-
-                    let (write_tx, write_rx) = mpsc::unbounded_channel::<ProtocolPacket>();
-                    let write_rx = Arc::new(Mutex::new(write_rx));
-
-                    let conn_id = CONN_COUNTER.fetch_add(1, Ordering::Relaxed);
-
-                    // Do NOT .await the spawn — blocks the accept loop until connection closes.
-                    tokio::spawn(handle_connection(
-                        event_tx.clone(),
-                        reader,
-                        writer,
-                        write_rx,
-                        peer,
-                        DeviceId(id.clone()),
-                        conn_id,
-                    ));
-
-                    if let Err(e) = event_tx.send(TransportEvent::NewConnection {
-                        addr: peer,
-                        id: DeviceId(peer_identity.device_id),
-                        name: name.clone(),
-                        write_tx,
-                        conn_id,
-                    }) {
-                        error!(peer = ?peer, "[tcp] transport event channel closed: {}", e);
-                    }
+                    });
                 }
                 Err(e) => {
                     warn!("[tcp] accept error: {}", e);
@@ -275,6 +359,174 @@ impl TcpTransport {
     }
 }
 
+async fn handle_incoming_tcp(
+    mut stream: TcpStream,
+    peer: SocketAddr,
+    event_tx: mpsc::UnboundedSender<TransportEvent>,
+    identity: Arc<Identity>,
+    client_config: Arc<rustls::ClientConfig>,
+    server_config: Arc<rustls::ServerConfig>,
+    rate_limiter: Arc<ConnectionRateLimiter>,
+) -> anyhow::Result<()> {
+    if !is_private_kdeconnect_addr(peer.ip()) {
+        return Err(anyhow::anyhow!(
+            "discarding TCP connection from non-local address {}",
+            peer.ip()
+        ));
+    }
+
+    // Step 1: read phone's pre-TLS identity.
+    // Read byte-by-byte to avoid BufReader consuming TLS ClientHello
+    // bytes into its internal buffer, which would cause "tls handshake eof".
+    debug!(peer = ?peer, "[tcp] step 1: reading pre-TLS identity");
+    let buffer = tokio::time::timeout(
+        Duration::from_secs(5),
+        read_line_bounded(&mut stream, MAX_IDENTITY_PACKET_SIZE),
+    )
+    .await??;
+    debug!(peer = ?peer, "[tcp] step 1: read {} bytes", buffer.len());
+
+    let packet = serde_json::from_str::<ProtocolPacket>(&buffer)?;
+    if !matches!(packet.packet_type, PacketType::Identity) {
+        return Err(anyhow::anyhow!(
+            "expected pre-TLS identity packet, received {:?}",
+            packet.packet_type
+        ));
+    }
+    let mut peer_identity = match serde_json::from_value::<Identity>(packet.body) {
+        Ok(i) => i,
+        Err(e) => {
+            // Complete the TLS handshake gracefully so the phone doesn't see
+            // an abrupt TCP drop and retry aggressively causing connection churn.
+            tokio::spawn(async move {
+                if let Ok(mut tls_stream) = TlsAcceptor::from(server_config).accept(stream).await {
+                    let _ = tls_stream.shutdown().await;
+                }
+            });
+            return Err(e.into());
+        }
+    };
+    validate_identity_target(&peer_identity, &identity)?;
+
+    let name = peer_identity.device_name.clone();
+    let id = peer_identity.device_id.clone();
+    let peer_protocol_version = peer_identity.protocol_version;
+    info!(peer = ?peer, device_id = ?id, device_name = name, "[tcp] identified peer");
+
+    if identity.device_id == peer_identity.device_id {
+        return Err(anyhow::anyhow!("skipping the same device"));
+    }
+
+    // Validate device ID and sanitize name early, before TLS.
+    crate::device::validate_device_id(&id)?;
+    let device_id = DeviceId(id.clone());
+    if !rate_limiter.allow_device_connection(&device_id).await {
+        debug!(
+            peer = ?peer,
+            device_id = ?device_id,
+            "[tcp] duplicate connection attempt suppressed"
+        );
+        return Ok(());
+    }
+    let name = crate::device::sanitize_device_name(&name);
+
+    // Step 2: TLS handshake. KDE Connect's LAN protocol makes the
+    // side accepting the TCP connection act as the TLS client.
+    debug!(peer = ?peer, "[tcp] step 2: starting TLS connect (we are client)");
+    let server_name = ServerName::try_from(id.as_str())?.to_owned();
+    let mut tls_stream = tokio::time::timeout(
+        Duration::from_secs(10),
+        TlsConnector::from(client_config).connect(server_name, stream),
+    )
+    .await??;
+
+    info!(peer = ?peer, device_id = ?id, "[tcp] step 2: TLS established");
+    let peer_certificate = peer_certificate_der(tls_stream.get_ref().1.peer_certificates());
+    if paired_certificate_mismatch(
+        &DeviceId(id.clone()),
+        &name,
+        peer_identity.device_type.to_string(),
+        peer_identity.incoming_capabilities.clone(),
+        peer_identity.outgoing_capabilities.clone(),
+        peer,
+        &peer_certificate,
+    )
+    .await
+    {
+        let _ = event_tx.send(TransportEvent::PairTrustFailed {
+            id: DeviceId(id.clone()),
+        });
+        let _ = tls_stream.shutdown().await;
+        return Err(anyhow::anyhow!(
+            "paired device presented a different TLS certificate"
+        ));
+    }
+
+    if peer_protocol_version >= 8 {
+        // Protocol v8 requires replacing the cleartext identity with the
+        // identity exchanged inside TLS before trusting capabilities.
+        debug!(peer = ?peer, "[tcp] step 3: exchanging secure identity");
+        let filtered = filtered_identity_for_device(&id).await;
+        peer_identity =
+            exchange_secure_identity(&mut tls_stream, &id, peer_protocol_version, &filtered)
+                .await?;
+        debug!(peer = ?peer, "[tcp] step 3: secure identity exchanged");
+    }
+
+    let name = crate::device::sanitize_device_name(&peer_identity.device_name);
+
+    let (reader, writer) = split(tls_stream);
+
+    let (write_tx, write_rx) = mpsc::unbounded_channel::<ProtocolPacket>();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let conn_id = CONN_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    {
+        let mut meta = CONN_METADATA
+            .lock()
+            .map_err(|_| anyhow::anyhow!("CONN_METADATA poisoned"))?;
+        meta.insert(
+            DeviceId(peer_identity.device_id.clone()),
+            ConnMetadata {
+                device_type: peer_identity.device_type.to_string(),
+                incoming_capabilities: peer_identity.incoming_capabilities,
+                outgoing_capabilities: peer_identity.outgoing_capabilities,
+                protocol_version: peer_identity.protocol_version,
+                pairing_timestamp: 0,
+                peer_certificate,
+                shutdown_tx: shutdown_tx.clone(),
+                incoming_conn_id: 0,
+            },
+        );
+    }
+
+    if let Err(e) = event_tx.send(TransportEvent::NewConnection {
+        addr: peer,
+        id: DeviceId(peer_identity.device_id),
+        name: name.clone(),
+        write_tx,
+        conn_id,
+    }) {
+        return Err(anyhow::anyhow!("transport event channel closed: {}", e));
+    }
+
+    tokio::spawn(handle_connection(
+        reader,
+        writer,
+        ConnectionContext {
+            event_tx: event_tx.clone(),
+            write_rx,
+            peer,
+            id: DeviceId(id.clone()),
+            conn_id,
+            shutdown_rx,
+        },
+    ));
+
+    Ok(())
+}
+
 pub struct UdpTransport {
     socket: Arc<UdpSocket>,
     discovery_interval: Duration,
@@ -282,10 +534,15 @@ pub struct UdpTransport {
     event_tx: mpsc::UnboundedSender<TransportEvent>,
     identity: Arc<Identity>,
     server_config: Arc<rustls::ServerConfig>,
+    broadcast_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
+    rate_limiter: Arc<ConnectionRateLimiter>,
 }
 
 impl UdpTransport {
-    pub async fn new(event_tx: &mpsc::UnboundedSender<TransportEvent>) -> Self {
+    pub async fn new(
+        event_tx: &mpsc::UnboundedSender<TransportEvent>,
+        rate_limiter: Arc<ConnectionRateLimiter>,
+    ) -> Self {
         let config = GLOBAL_CONFIG.get().unwrap();
 
         let socket = {
@@ -302,11 +559,17 @@ impl UdpTransport {
                             tracing::error!(
                                 "UDP port {} still in use after {} attempts — \
                                  another instance may be running, exiting: {}",
-                                config.listen_addr.port(), attempts, e
+                                config.listen_addr.port(),
+                                attempts,
+                                e
                             );
                             std::process::exit(1);
                         }
-                        tracing::warn!("UDP bind failed (attempt {}), retrying in 1s: {}", attempts, e);
+                        tracing::warn!(
+                            "UDP bind failed (attempt {}), retrying in 1s: {}",
+                            attempts,
+                            e
+                        );
                         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                     }
                 }
@@ -326,6 +589,8 @@ impl UdpTransport {
             event_tx,
             identity,
             server_config,
+            broadcast_handle: Arc::new(Mutex::new(None)),
+            rate_limiter,
         }
     }
 
@@ -333,6 +598,15 @@ impl UdpTransport {
         if std::env::var("KDECONNECT_DISABLE_UDP_BROADCAST").is_ok() {
             warn!("UDP broadcast disabled by environment variable");
             return Ok(());
+        }
+
+        // Cancel any previously-spawned broadcast task so we never accumulate
+        // orphaned broadcast loops.
+        {
+            let mut guard = self.broadcast_handle.lock().await;
+            if let Some(handle) = guard.take() {
+                handle.abort();
+            }
         }
 
         debug!("Broadcasting UDP identity packet");
@@ -346,35 +620,53 @@ impl UdpTransport {
         .as_raw()
         .expect("Failed to serialize identity packet");
 
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_secs(1)).await;
-            let mut interval = tokio::time::interval(Duration::from_secs(interval.as_secs()));
-            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
-
-            loop {
+        let handle = tokio::spawn(async move {
+            // Send a short burst immediately for explicit scans. UDP broadcast is
+            // intentionally lossy on many Wi-Fi networks, so a single packet can
+            // be missed even when discovery should work.
+            for _ in 0..IDENTITY_BURST_COUNT {
                 match udp_socket.send_to(packet.as_slice(), BROADCAST_ADDR).await {
                     Ok(size) => {
                         debug!(addr = ?BROADCAST_ADDR, packet.size = size, "Sending udp broadcast")
                     }
                     Err(e) => warn!(addr = ?BROADCAST_ADDR, "Failed to send UDP packet: {}", e),
                 }
+                tokio::time::sleep(IDENTITY_BURST_DELAY).await;
+            }
+
+            let mut interval = tokio::time::interval(Duration::from_secs(interval.as_secs()));
+            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+            loop {
                 interval.tick().await;
+                match udp_socket.send_to(packet.as_slice(), BROADCAST_ADDR).await {
+                    Ok(size) => {
+                        debug!(addr = ?BROADCAST_ADDR, packet.size = size, "Sending udp broadcast")
+                    }
+                    Err(e) => warn!(addr = ?BROADCAST_ADDR, "Failed to send UDP packet: {}", e),
+                }
             }
         });
+
+        *self.broadcast_handle.lock().await = Some(handle);
 
         Ok(())
     }
 
     pub async fn listen(&self) -> anyhow::Result<()> {
-        let event_tx = self.event_tx.clone();
-        let this_identity = self.identity.clone();
+        let mut buf = vec![0u8; MAX_IDENTITY_PACKET_SIZE];
 
         loop {
-            let this_identity = this_identity.clone();
-            let mut buf = vec![0u8; 8192];
-
             match self.socket.recv_from(&mut buf).await {
-                Ok((len, mut peer)) => {
+                Ok((len, peer)) => {
+                    if !is_private_kdeconnect_addr(peer.ip()) {
+                        debug!(
+                            peer = ?peer,
+                            "[udp] discarding identity from non-local address"
+                        );
+                        continue;
+                    }
+
                     let raw = &buf[..len];
                     let packet = match ProtocolPacket::from_raw(raw) {
                         Ok(p) => p,
@@ -383,97 +675,45 @@ impl UdpTransport {
                             continue;
                         }
                     };
+                    if !matches!(packet.packet_type, PacketType::Identity) {
+                        debug!(
+                            "[udp] ignoring non-identity packet {:?}",
+                            packet.packet_type
+                        );
+                        continue;
+                    }
 
-                    if let Ok(peer_identity) = serde_json::from_value::<Identity>(packet.body) {
-                        if this_identity.device_id == peer_identity.device_id {
-                            warn!("[udp] skipping the same device");
+                    let peer_identity = match serde_json::from_value::<Identity>(packet.body) {
+                        Ok(i) => i,
+                        Err(e) => {
+                            warn!("[udp] failed to parse identity body: {}", e);
                             continue;
                         }
+                    };
 
-                        let id = DeviceId(peer_identity.device_id.clone());
-                        let name = peer_identity.device_name.clone();
-
-                        if let Some(new_port) = peer_identity.tcp_port {
-                            peer.set_port(new_port);
-                            info!(peer = ?peer, device_id = ?id, device_name = name, "Device supports TCP");
-                        }
-
-                        let mut stream = match TcpStream::connect(peer).await {
-                            Ok(s) => {
-                                apply_keepalive(&s);
-                                s
-                            }
-                            Err(e) => {
-                                warn!(peer = ?peer, "[udp] TCP connect failed: {}", e);
-                                continue;
-                            }
-                        };
-
-                        // Send identity pre-TLS — phone reads this before initiating TLS.
-                        let pre_tls_identity = ProtocolPacket::new(
-                            PacketType::Identity,
-                            serde_json::to_value(&*self.identity).unwrap(),
-                        )
-                        .as_raw()
-                        .expect("Failed to serialize identity packet");
-
-                        let _ = stream.write_all(pre_tls_identity.as_slice()).await;
-                        let _ = stream.flush().await;
-
-                        let acceptor = TlsAcceptor::from(self.server_config.clone());
-
-                        let mut tls_stream = match acceptor.accept(stream).await {
-                            Ok(s) => s,
-                            Err(e) => {
-                                warn!(peer = ?peer, "[udp] TLS handshake failed: {}", e);
-                                continue;
-                            }
-                        };
-
-                        info!(peer = ?peer, device_id = ?id, device_name = name, "[udp] Established TLS connection");
-
-                        // Send identity post-TLS — phone uses this for plugin negotiation.
-                        // Filter capabilities based on per-device disabled plugins so
-                        // the phone immediately knows which packet types to stop sending.
-                        let filtered = filtered_identity_for_device(&id.0).await;
-                        let post_tls_identity = ProtocolPacket::new(
-                            PacketType::Identity,
-                            serde_json::to_value(&filtered).unwrap(),
-                        )
-                        .as_raw()
-                        .expect("Failed to serialize identity packet");
-
-                        let _ = tls_stream.write_all(post_tls_identity.as_slice()).await;
-                        let _ = tls_stream.flush().await;
-
-                        let (reader, writer) = split(tls_stream);
-
-                        let (write_tx, write_rx) = mpsc::unbounded_channel::<ProtocolPacket>();
-                        let write_rx = Arc::new(Mutex::new(write_rx));
-
-                        let conn_id = CONN_COUNTER.fetch_add(1, Ordering::Relaxed);
-
-                        // Do NOT .await the spawn — blocks the UDP listen loop.
-                        tokio::spawn(handle_connection(
-                            event_tx.clone(),
-                            reader,
-                            writer,
-                            write_rx,
-                            peer,
-                            id.clone(),
-                            conn_id,
-                        ));
-
-                        if let Err(e) = event_tx.send(TransportEvent::NewConnection {
-                            addr: peer,
-                            id: DeviceId(peer_identity.device_id),
-                            name: name.clone(),
-                            write_tx,
-                            conn_id,
-                        }) {
-                            error!(peer = ?peer, device_id = ?id, "[udp] transport event channel closed: {}", e);
-                        }
+                    if self.identity.device_id == peer_identity.device_id {
+                        continue;
                     }
+
+                    let event_tx = self.event_tx.clone();
+                    let this_identity = self.identity.clone();
+                    let server_config = self.server_config.clone();
+                    let rate_limiter = self.rate_limiter.clone();
+
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_discovered_device(
+                            peer,
+                            peer_identity,
+                            event_tx,
+                            this_identity,
+                            server_config,
+                            rate_limiter,
+                        )
+                        .await
+                        {
+                            warn!(peer = ?peer, "[udp] failed to handle discovery: {}", e);
+                        }
+                    });
                 }
                 Err(e) => {
                     warn!("[udp] recv_from error: {}", e);
@@ -483,29 +723,274 @@ impl UdpTransport {
     }
 }
 
-async fn handle_connection<R, W>(
+async fn handle_discovered_device(
+    mut peer: SocketAddr,
+    mut peer_identity: Identity,
     event_tx: mpsc::UnboundedSender<TransportEvent>,
-    reader: R,
-    mut writer: W,
-    write_rx: Arc<Mutex<mpsc::UnboundedReceiver<ProtocolPacket>>>,
+    this_identity: Arc<Identity>,
+    server_config: Arc<rustls::ServerConfig>,
+    rate_limiter: Arc<ConnectionRateLimiter>,
+) -> anyhow::Result<()> {
+    if !is_private_kdeconnect_addr(peer.ip()) {
+        return Err(anyhow::anyhow!(
+            "discarding UDP discovery from non-local address {}",
+            peer.ip()
+        ));
+    }
+
+    let id = DeviceId(peer_identity.device_id.clone());
+    let name = peer_identity.device_name.clone();
+    let peer_protocol_version = peer_identity.protocol_version;
+
+    // Validate device ID and sanitize name early.
+    crate::device::validate_device_id(&id.0)?;
+    if !rate_limiter.allow_device_connection(&id).await {
+        debug!(
+            peer = ?peer,
+            device_id = ?id,
+            "[udp] duplicate discovery connection suppressed"
+        );
+        return Ok(());
+    }
+    let name = crate::device::sanitize_device_name(&name);
+
+    if let Some(new_port) = peer_identity.tcp_port {
+        peer.set_port(new_port);
+        info!(peer = ?peer, device_id = ?id, device_name = name, "Device supports TCP");
+    }
+
+    let mut stream =
+        tokio::time::timeout(Duration::from_secs(5), TcpStream::connect(peer)).await??;
+    apply_keepalive(&stream);
+
+    // Send identity pre-TLS — phone reads this before initiating TLS.
+    let pre_tls_identity = targeted_identity(&this_identity, &id.0, peer_protocol_version);
+    let pre_tls_identity = ProtocolPacket::new(
+        PacketType::Identity,
+        serde_json::to_value(&pre_tls_identity)?,
+    )
+    .as_raw()?;
+    stream.write_all(pre_tls_identity.as_slice()).await?;
+    stream.flush().await?;
+
+    let acceptor = TlsAcceptor::from(server_config);
+
+    let mut tls_stream =
+        tokio::time::timeout(Duration::from_secs(10), acceptor.accept(stream)).await??;
+
+    info!(peer = ?peer, device_id = ?id, device_name = name, "[udp] Established TLS connection");
+    let peer_certificate = peer_certificate_der(tls_stream.get_ref().1.peer_certificates());
+    if paired_certificate_mismatch(
+        &id,
+        &name,
+        peer_identity.device_type.to_string(),
+        peer_identity.incoming_capabilities.clone(),
+        peer_identity.outgoing_capabilities.clone(),
+        peer,
+        &peer_certificate,
+    )
+    .await
+    {
+        let _ = event_tx.send(TransportEvent::PairTrustFailed { id });
+        let _ = tls_stream.shutdown().await;
+        return Err(anyhow::anyhow!(
+            "paired device presented a different TLS certificate"
+        ));
+    }
+
+    if peer_protocol_version >= 8 {
+        let filtered = filtered_identity_for_device(&id.0).await;
+        peer_identity =
+            exchange_secure_identity(&mut tls_stream, &id.0, peer_protocol_version, &filtered)
+                .await?;
+    }
+
+    let name = crate::device::sanitize_device_name(&peer_identity.device_name);
+
+    let (reader, writer) = split(tls_stream);
+
+    let (write_tx, write_rx) = mpsc::unbounded_channel::<ProtocolPacket>();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let conn_id = CONN_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    {
+        let mut meta = CONN_METADATA
+            .lock()
+            .map_err(|_| anyhow::anyhow!("CONN_METADATA poisoned"))?;
+        meta.insert(
+            DeviceId(peer_identity.device_id.clone()),
+            ConnMetadata {
+                device_type: peer_identity.device_type.to_string(),
+                incoming_capabilities: peer_identity.incoming_capabilities,
+                outgoing_capabilities: peer_identity.outgoing_capabilities,
+                protocol_version: peer_identity.protocol_version,
+                pairing_timestamp: 0,
+                peer_certificate,
+                shutdown_tx: shutdown_tx.clone(),
+                incoming_conn_id: 0,
+            },
+        );
+    }
+
+    if let Err(e) = event_tx.send(TransportEvent::NewConnection {
+        addr: peer,
+        id: DeviceId(peer_identity.device_id),
+        name: name.clone(),
+        write_tx,
+        conn_id,
+    }) {
+        return Err(anyhow::anyhow!("transport event channel closed: {}", e));
+    }
+
+    tokio::spawn(handle_connection(
+        reader,
+        writer,
+        ConnectionContext {
+            event_tx: event_tx.clone(),
+            write_rx,
+            peer,
+            id: id.clone(),
+            conn_id,
+            shutdown_rx,
+        },
+    ));
+
+    Ok(())
+}
+
+fn peer_certificate_der(certs: Option<&[rustls::pki_types::CertificateDer<'static>]>) -> Vec<u8> {
+    certs
+        .and_then(|certs| certs.first())
+        .map(|cert| cert.as_ref().to_vec())
+        .unwrap_or_default()
+}
+
+async fn paired_certificate_mismatch(
+    id: &DeviceId,
+    name: &str,
+    device_type: String,
+    incoming_capabilities: Vec<String>,
+    outgoing_capabilities: Vec<String>,
+    addr: SocketAddr,
+    peer_certificate: &[u8],
+) -> bool {
+    if peer_certificate.is_empty() {
+        return false;
+    }
+
+    let Ok(device) = Device::from_discovery(
+        id.0.clone(),
+        name.to_string(),
+        device_type,
+        incoming_capabilities,
+        outgoing_capabilities,
+        addr,
+    )
+    .await
+    else {
+        return false;
+    };
+
+    let mismatch = device.pair_state == PairState::Paired
+        && !device.remote_certificate.is_empty()
+        && device.remote_certificate != peer_certificate;
+
+    if mismatch {
+        let _ = device.update_pair_state(PairState::NotPaired).await;
+    }
+
+    mismatch
+}
+
+struct ConnectionContext {
+    event_tx: mpsc::UnboundedSender<TransportEvent>,
+    write_rx: mpsc::UnboundedReceiver<ProtocolPacket>,
     peer: SocketAddr,
     id: DeviceId,
     conn_id: u64,
-) where
+    shutdown_rx: watch::Receiver<bool>,
+}
+
+enum InterruptibleIo {
+    Completed(std::io::Result<()>),
+    Interrupted,
+}
+
+async fn write_all_interruptible<W>(
+    writer: &mut W,
+    bytes: &[u8],
+    shutdown_rx: &mut watch::Receiver<bool>,
+    local_close_rx: &mut watch::Receiver<bool>,
+) -> InterruptibleIo
+where
+    W: AsyncWrite + Unpin,
+{
+    tokio::select! {
+        biased;
+        _ = shutdown_rx.changed() => InterruptibleIo::Interrupted,
+        _ = local_close_rx.changed() => InterruptibleIo::Interrupted,
+        result = writer.write_all(bytes) => InterruptibleIo::Completed(result),
+    }
+}
+
+async fn flush_interruptible<W>(
+    writer: &mut W,
+    shutdown_rx: &mut watch::Receiver<bool>,
+    local_close_rx: &mut watch::Receiver<bool>,
+) -> InterruptibleIo
+where
+    W: AsyncWrite + Unpin,
+{
+    tokio::select! {
+        biased;
+        _ = shutdown_rx.changed() => InterruptibleIo::Interrupted,
+        _ = local_close_rx.changed() => InterruptibleIo::Interrupted,
+        result = writer.flush() => InterruptibleIo::Completed(result),
+    }
+}
+
+async fn handle_connection<R, W>(reader: R, mut writer: W, context: ConnectionContext)
+where
     R: tokio::io::AsyncRead + Unpin + Send + 'static,
     W: tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
+    let ConnectionContext {
+        event_tx,
+        mut write_rx,
+        peer,
+        id,
+        conn_id,
+        shutdown_rx,
+    } = context;
     let mut reader = BufReader::new(reader);
     let mut buffer = String::new();
+    let (local_close_tx, local_close_rx) = watch::channel(false);
 
     // Reader task — forwards packets and emits Disconnected when the connection ends.
     let event_tx_reader = event_tx.clone();
     let id_reader = id.clone();
+    let mut shutdown_rx_reader = shutdown_rx.clone();
+    let mut local_close_rx_reader = local_close_rx.clone();
+    let local_close_tx_reader = local_close_tx.clone();
     tokio::spawn(async move {
         loop {
-            match reader.read_line(&mut buffer).await {
+            let read_result = tokio::select! {
+                biased;
+                _ = shutdown_rx_reader.changed() => {
+                    debug!(peer = ?peer, "[reader loop] shutting down superseded connection");
+                    break;
+                }
+                _ = local_close_rx_reader.changed() => {
+                    debug!(peer = ?peer, "[reader loop] writer ended connection");
+                    break;
+                }
+                result = reader.read_line(&mut buffer) => result,
+            };
+
+            match read_result {
                 Ok(0) => {
-                    warn!(peer = ?peer, "[reader loop] connection closed");
+                    debug!(peer = ?peer, "[reader loop] connection closed");
                     break;
                 }
                 Ok(_) => {
@@ -519,6 +1004,12 @@ async fn handle_connection<R, W>(
                     // sensitive data eg. from sms
                     // eprintln!("[reader] raw bytes from {}: {:?}", peer, trimmed);
 
+                    if let Ok(mut meta) = CONN_METADATA.lock() {
+                        if let Some(data) = meta.get_mut(&id_reader) {
+                            data.incoming_conn_id = conn_id;
+                        }
+                    }
+
                     if let Err(e) = event_tx_reader.send(TransportEvent::IncomingPacket {
                         addr: peer,
                         id: id_reader.clone(),
@@ -529,13 +1020,23 @@ async fn handle_connection<R, W>(
                     }
                 }
                 Err(e) => {
-                    error!(peer = ?peer, "[reader loop] error reading: {}", e);
+                    if matches!(
+                        e.kind(),
+                        std::io::ErrorKind::ConnectionReset
+                            | std::io::ErrorKind::UnexpectedEof
+                            | std::io::ErrorKind::BrokenPipe
+                    ) {
+                        debug!(peer = ?peer, "[reader loop] connection ended: {}", e);
+                    } else {
+                        error!(peer = ?peer, "[reader loop] error reading: {}", e);
+                    }
                     break;
                 }
             }
             buffer.clear();
         }
-        warn!(peer = ?peer, "reader loop ended");
+        debug!(peer = ?peer, "reader loop ended");
+        let _ = local_close_tx_reader.send(true);
         // Notify core the connection is dead. conn_id lets core distinguish this
         // disconnect from a stale event belonging to a previous connection.
         let _ = event_tx_reader.send(TransportEvent::Disconnected {
@@ -544,21 +1045,142 @@ async fn handle_connection<R, W>(
         });
     });
 
-    // Writer task — drains the write channel and sends packets to the peer.
+    // Writer task — drains the write channel and sends periodic bare-newline
+    // keepalives to prevent the TCP connection from going idle.
+    let event_tx_writer = event_tx.clone();
+    let id_writer = id.clone();
+    let mut shutdown_rx_writer = shutdown_rx;
+    let mut local_close_rx_writer = local_close_rx;
+    let local_close_tx_writer = local_close_tx;
     tokio::spawn(async move {
-        while let Some(msg) = write_rx.lock().await.recv().await {
-            debug!(peer = ?peer, packet_type = ?msg.packet_type, "writing");
+        let mut close_gracefully = true;
+        loop {
+            let msg = tokio::select! {
+                biased;
+                _ = shutdown_rx_writer.changed() => {
+                    debug!(peer = ?peer, "writer shutting down superseded connection");
+                    close_gracefully = false;
+                    break;
+                }
+                _ = local_close_rx_writer.changed() => {
+                    debug!(peer = ?peer, "writer shutting down because reader ended");
+                    close_gracefully = false;
+                    break;
+                }
+                msg = write_rx.recv() => msg,
+                _ = tokio::time::sleep(HEARTBEAT_INTERVAL) => {
+                    match write_all_interruptible(
+                        &mut writer,
+                        b"\n",
+                        &mut shutdown_rx_writer,
+                        &mut local_close_rx_writer,
+                    )
+                    .await
+                    {
+                        InterruptibleIo::Completed(Ok(())) => {}
+                        InterruptibleIo::Completed(Err(e)) => {
+                            error!(peer = ?peer, "Error writing heartbeat: {}", e);
+                            close_gracefully = false;
+                            break;
+                        }
+                        InterruptibleIo::Interrupted => {
+                            close_gracefully = false;
+                            break;
+                        }
+                    }
+                    match flush_interruptible(
+                        &mut writer,
+                        &mut shutdown_rx_writer,
+                        &mut local_close_rx_writer,
+                    )
+                    .await
+                    {
+                        InterruptibleIo::Completed(Ok(())) => {}
+                        InterruptibleIo::Completed(Err(e)) => {
+                            error!(peer = ?peer, "Error flushing heartbeat: {}", e);
+                            close_gracefully = false;
+                            break;
+                        }
+                        InterruptibleIo::Interrupted => {
+                            close_gracefully = false;
+                            break;
+                        }
+                    }
+                    continue;
+                }
+            };
+            match msg {
+                Some(msg) => {
+                    debug!(peer = ?peer, packet_type = ?msg.packet_type, "writing");
+                    let packet_type = msg.packet_type.clone();
 
-            if let Err(e) = writer.write_all(&msg.as_raw().unwrap()).await {
-                error!(peer = ?peer, "Error writing: {}", e);
-                break;
-            }
-            if let Err(e) = writer.flush().await {
-                error!(peer = ?peer, "Error flushing: {}", e);
-                break;
+                    let raw = match msg.as_raw() {
+                        Ok(raw) => raw,
+                        Err(e) => {
+                            error!(peer = ?peer, "Error serializing packet: {}", e);
+                            continue;
+                        }
+                    };
+
+                    match write_all_interruptible(
+                        &mut writer,
+                        &raw,
+                        &mut shutdown_rx_writer,
+                        &mut local_close_rx_writer,
+                    )
+                    .await
+                    {
+                        InterruptibleIo::Completed(Ok(())) => {}
+                        InterruptibleIo::Completed(Err(e)) => {
+                            error!(peer = ?peer, "Error writing: {}", e);
+                            close_gracefully = false;
+                            let _ = event_tx_writer.send(TransportEvent::PacketSendFailed {
+                                id: id_writer.clone(),
+                                packet_type,
+                                conn_id,
+                            });
+                            break;
+                        }
+                        InterruptibleIo::Interrupted => {
+                            close_gracefully = false;
+                            break;
+                        }
+                    }
+                    match flush_interruptible(
+                        &mut writer,
+                        &mut shutdown_rx_writer,
+                        &mut local_close_rx_writer,
+                    )
+                    .await
+                    {
+                        InterruptibleIo::Completed(Ok(())) => {}
+                        InterruptibleIo::Completed(Err(e)) => {
+                            error!(peer = ?peer, "Error flushing: {}", e);
+                            close_gracefully = false;
+                            let _ = event_tx_writer.send(TransportEvent::PacketSendFailed {
+                                id: id_writer.clone(),
+                                packet_type,
+                                conn_id,
+                            });
+                            break;
+                        }
+                        InterruptibleIo::Interrupted => {
+                            close_gracefully = false;
+                            break;
+                        }
+                    }
+                }
+                None => break,
             }
         }
-        let _ = writer.shutdown().await;
+        if close_gracefully {
+            let _ = tokio::time::timeout(TLS_SHUTDOWN_TIMEOUT, writer.shutdown()).await;
+        }
+        let _ = local_close_tx_writer.send(true);
+        let _ = event_tx_writer.send(TransportEvent::Disconnected {
+            id: id_writer,
+            conn_id,
+        });
         info!(peer = ?peer, "writer task ended");
     });
 }
@@ -577,23 +1199,103 @@ async fn filtered_identity_for_device(device_id: &str) -> Identity {
     // Map plugin IDs to the capability strings they own.
     // (incoming_caps, outgoing_caps)
     let cap_map: &[(&str, &[&str], &[&str])] = &[
-        ("battery",             &["kdeconnect.battery"],                                                    &["kdeconnect.battery.request"]),
-        ("clipboard",           &["kdeconnect.clipboard", "kdeconnect.clipboard.connect"],                  &["kdeconnect.clipboard"]),
-        ("connectivity_report", &["kdeconnect.connectivity_report"],                                        &[]),
-        ("contacts",            &["kdeconnect.contacts.response_uids_timestamps",
-                                   "kdeconnect.contacts.response_vcards"],                                  &["kdeconnect.contacts.request_all_uids_timestamps",
-                                                                                                              "kdeconnect.contacts.request_vcards_by_uid"]),
-        ("findmyphone",         &[],                                                                        &["kdeconnect.findmyphone.request"]),
-        ("mpris",               &["kdeconnect.mpris", "kdeconnect.mpris.request"],                          &["kdeconnect.mpris", "kdeconnect.mpris.request"]),
-        ("notification",        &["kdeconnect.notification"],                                               &["kdeconnect.notification.request"]),
-        ("ping",                &["kdeconnect.ping"],                                                       &["kdeconnect.ping"]),
-        ("runcommand",          &["kdeconnect.runcommand.request"],                                         &["kdeconnect.runcommand"]),
-        ("share",               &["kdeconnect.share.request"],                                              &["kdeconnect.share.request", "kdeconnect.share.request.update"]),
-        ("sms",                 &["kdeconnect.sms.messages", "kdeconnect.sms.attachment_file"],             &["kdeconnect.sms.request",
-                                                                                                              "kdeconnect.sms.request_conversations",
-                                                                                                              "kdeconnect.sms.request_conversation",
-                                                                                                              "kdeconnect.sms.request_attachment"]),
-        ("telephony",           &["kdeconnect.telephony"],                                                  &["kdeconnect.telephony.request_mute"]),                                                                                                      
+        (
+            "battery",
+            &["kdeconnect.battery", "kdeconnect.battery.request"],
+            &["kdeconnect.battery", "kdeconnect.battery.request"],
+        ),
+        (
+            "clipboard",
+            &["kdeconnect.clipboard", "kdeconnect.clipboard.connect"],
+            &["kdeconnect.clipboard", "kdeconnect.clipboard.connect"],
+        ),
+        (
+            "connectivity_report",
+            &["kdeconnect.connectivity_report"],
+            &["kdeconnect.connectivity_report.request"],
+        ),
+        (
+            "contacts",
+            &[
+                "kdeconnect.contacts.response_uids_timestamps",
+                "kdeconnect.contacts.response_vcards",
+            ],
+            &[
+                "kdeconnect.contacts.request_all_uids_timestamps",
+                "kdeconnect.contacts.request_vcards_by_uid",
+            ],
+        ),
+        (
+            "findmyphone",
+            &["kdeconnect.findmyphone.request"],
+            &["kdeconnect.findmyphone.request"],
+        ),
+        (
+            "mousepad",
+            &[
+                "kdeconnect.mousepad.echo",
+                "kdeconnect.mousepad.keyboardstate",
+                "kdeconnect.mousepad.request",
+            ],
+            &[
+                "kdeconnect.mousepad.echo",
+                "kdeconnect.mousepad.keyboardstate",
+                "kdeconnect.mousepad.request",
+            ],
+        ),
+        (
+            "mpris",
+            &["kdeconnect.mpris", "kdeconnect.mpris.request"],
+            &["kdeconnect.mpris", "kdeconnect.mpris.request"],
+        ),
+        (
+            "notification",
+            &["kdeconnect.notification", "kdeconnect.notification.request"],
+            &[
+                "kdeconnect.notification",
+                "kdeconnect.notification.action",
+                "kdeconnect.notification.reply",
+                "kdeconnect.notification.request",
+            ],
+        ),
+        ("ping", &["kdeconnect.ping"], &["kdeconnect.ping"]),
+        ("presenter", &["kdeconnect.presenter"], &[]),
+        (
+            "runcommand",
+            &["kdeconnect.runcommand", "kdeconnect.runcommand.request"],
+            &["kdeconnect.runcommand", "kdeconnect.runcommand.request"],
+        ),
+        (
+            "share",
+            &["kdeconnect.share.request"],
+            &["kdeconnect.share.request"],
+        ),
+        (
+            "digitizer",
+            &["kdeconnect.digitizer", "kdeconnect.digitizer.session"],
+            &[],
+        ),
+        ("sftp", &["kdeconnect.sftp"], &["kdeconnect.sftp.request"]),
+        (
+            "sms",
+            &["kdeconnect.sms.messages", "kdeconnect.sms.attachment_file"],
+            &[
+                "kdeconnect.sms.request",
+                "kdeconnect.sms.request_conversations",
+                "kdeconnect.sms.request_conversation",
+                "kdeconnect.sms.request_attachment",
+            ],
+        ),
+        (
+            "systemvolume",
+            &["kdeconnect.systemvolume.request"],
+            &["kdeconnect.systemvolume"],
+        ),
+        (
+            "telephony",
+            &["kdeconnect.telephony"],
+            &["kdeconnect.telephony.request_mute"],
+        ),
     ];
 
     let mut remove_inc: std::collections::HashSet<&str> = std::collections::HashSet::new();
@@ -613,11 +1315,15 @@ async fn filtered_identity_for_device(device_id: &str) -> Identity {
         tcp_port: base.tcp_port,
         target_device_id: None,
         target_protocol_version: None,
-        incoming_capabilities: base.incoming_capabilities.iter()
+        incoming_capabilities: base
+            .incoming_capabilities
+            .iter()
             .filter(|c| !remove_inc.contains(c.as_str()))
             .cloned()
             .collect(),
-        outgoing_capabilities: base.outgoing_capabilities.iter()
+        outgoing_capabilities: base
+            .outgoing_capabilities
+            .iter()
             .filter(|c| !remove_out.contains(c.as_str()))
             .cloned()
             .collect(),
@@ -654,13 +1360,220 @@ pub(crate) async fn receive_payload(
 
     debug!("connected");
 
-    if let Ok(mut save_path) = tokio::fs::File::create(&temp_file).await {
-        let _ = tokio::io::copy(&mut stream, &mut save_path).await;
-        let _ = stream.flush().await;
-        let _ = stream.shutdown().await;
+    if let Some(parent) = temp_file.parent() {
+        tokio::fs::create_dir_all(parent).await?;
     }
+
+    let mut save_path = tokio::fs::File::create(temp_file).await?;
+    tokio::io::copy(&mut stream, &mut save_path).await?;
+    save_path.flush().await?;
+    stream.shutdown().await?;
 
     info!("successfully received payload");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ConnectionContext, ConnectionRateLimiter, TransportEvent, handle_connection,
+        is_private_kdeconnect_addr,
+    };
+    use crate::{
+        device::DeviceId,
+        protocol::{PacketType, ProtocolPacket},
+    };
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4};
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt, DuplexStream, duplex, split},
+        sync::{mpsc, watch},
+        time::{Duration, timeout},
+    };
+
+    async fn start_test_connection_with_capacity(
+        conn_id: u64,
+        capacity: usize,
+    ) -> (
+        mpsc::UnboundedSender<ProtocolPacket>,
+        mpsc::UnboundedReceiver<TransportEvent>,
+        watch::Sender<bool>,
+        DuplexStream,
+        DeviceId,
+    ) {
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        let (local, remote) = duplex(capacity);
+        let (reader, writer) = split(local);
+        let (write_tx, write_rx) = mpsc::unbounded_channel();
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let id = DeviceId(format!("transport-regression-{conn_id}"));
+        let peer = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1716));
+
+        handle_connection(
+            reader,
+            writer,
+            ConnectionContext {
+                event_tx,
+                write_rx,
+                peer,
+                id: id.clone(),
+                conn_id,
+                shutdown_rx,
+            },
+        )
+        .await;
+
+        (write_tx, event_rx, shutdown_tx, remote, id)
+    }
+
+    async fn start_test_connection(
+        conn_id: u64,
+    ) -> (
+        mpsc::UnboundedSender<ProtocolPacket>,
+        mpsc::UnboundedReceiver<TransportEvent>,
+        watch::Sender<bool>,
+        DuplexStream,
+        DeviceId,
+    ) {
+        start_test_connection_with_capacity(conn_id, 4096).await
+    }
+
+    async fn wait_for_disconnect(
+        event_rx: &mut mpsc::UnboundedReceiver<TransportEvent>,
+        id: &DeviceId,
+        conn_id: u64,
+    ) {
+        timeout(Duration::from_secs(1), async {
+            loop {
+                match event_rx
+                    .recv()
+                    .await
+                    .expect("transport event channel closed")
+                {
+                    TransportEvent::Disconnected {
+                        id: disconnected_id,
+                        conn_id: disconnected_conn_id,
+                    } if &disconnected_id == id && disconnected_conn_id == conn_id => break,
+                    _ => {}
+                }
+            }
+        })
+        .await
+        .expect("connection did not report disconnect");
+    }
+
+    async fn wait_for_writer_to_close(write_tx: &mpsc::UnboundedSender<ProtocolPacket>) {
+        timeout(Duration::from_secs(1), async {
+            loop {
+                let packet = ProtocolPacket::new(PacketType::Ping, serde_json::json!({}));
+                if write_tx.send(packet).is_err() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("writer stayed alive after connection shutdown");
+    }
+
+    #[test]
+    fn kdeconnect_lan_filter_allows_private_link_local_loopback_and_cgnat() {
+        assert!(is_private_kdeconnect_addr(IpAddr::V4(Ipv4Addr::new(
+            192, 168, 1, 2
+        ))));
+        assert!(is_private_kdeconnect_addr(IpAddr::V4(Ipv4Addr::new(
+            169, 254, 1, 2
+        ))));
+        assert!(is_private_kdeconnect_addr(IpAddr::V4(Ipv4Addr::LOCALHOST)));
+        assert!(is_private_kdeconnect_addr(IpAddr::V4(Ipv4Addr::new(
+            100, 64, 1, 2
+        ))));
+        assert!(is_private_kdeconnect_addr(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+        assert!(is_private_kdeconnect_addr(IpAddr::V6(
+            "fc00::1".parse().unwrap()
+        )));
+    }
+
+    #[test]
+    fn kdeconnect_lan_filter_rejects_public_internet_addresses() {
+        assert!(!is_private_kdeconnect_addr(IpAddr::V4(Ipv4Addr::new(
+            8, 8, 8, 8
+        ))));
+        assert!(!is_private_kdeconnect_addr(IpAddr::V6(
+            "2001:4860:4860::8888".parse().unwrap()
+        )));
+    }
+
+    #[tokio::test]
+    async fn rate_limiter_suppresses_immediate_duplicate_device_connections() {
+        let limiter = ConnectionRateLimiter::default();
+        let id = DeviceId("duplicate-device-000000000000000".to_string());
+
+        assert!(limiter.allow_device_connection(&id).await);
+        assert!(!limiter.allow_device_connection(&id).await);
+    }
+
+    #[tokio::test]
+    async fn reader_eof_closes_writer_without_waiting_for_heartbeat() {
+        let (write_tx, mut event_rx, _shutdown_tx, mut remote, id) =
+            start_test_connection(100).await;
+
+        remote.shutdown().await.unwrap();
+
+        wait_for_disconnect(&mut event_rx, &id, 100).await;
+        wait_for_writer_to_close(&write_tx).await;
+    }
+
+    #[tokio::test]
+    async fn presenter_burst_then_peer_close_drops_writer() {
+        let (write_tx, mut event_rx, _shutdown_tx, mut remote, id) =
+            start_test_connection(101).await;
+
+        for _ in 0..32 {
+            let packet = ProtocolPacket::new(
+                PacketType::Presenter,
+                serde_json::json!({ "dx": 0.01, "dy": -0.02 }),
+            );
+            remote.write_all(&packet.as_raw().unwrap()).await.unwrap();
+        }
+        let stop = ProtocolPacket::new(PacketType::Presenter, serde_json::json!({ "stop": true }));
+        remote.write_all(&stop.as_raw().unwrap()).await.unwrap();
+        remote.shutdown().await.unwrap();
+
+        wait_for_disconnect(&mut event_rx, &id, 101).await;
+        wait_for_writer_to_close(&write_tx).await;
+    }
+
+    #[tokio::test]
+    async fn superseded_transport_shutdown_drops_writer() {
+        let (write_tx, mut event_rx, shutdown_tx, _remote, id) = start_test_connection(102).await;
+
+        shutdown_tx.send(true).unwrap();
+
+        wait_for_disconnect(&mut event_rx, &id, 102).await;
+        wait_for_writer_to_close(&write_tx).await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_interrupts_writer_blocked_by_unread_peer() {
+        let (write_tx, mut event_rx, shutdown_tx, mut remote, id) =
+            start_test_connection_with_capacity(103, 64).await;
+
+        let packet = ProtocolPacket::new(
+            PacketType::Ping,
+            serde_json::json!({ "message": "x".repeat(8192) }),
+        );
+        write_tx.send(packet).unwrap();
+
+        let mut first_byte = [0u8; 1];
+        timeout(Duration::from_secs(1), remote.read_exact(&mut first_byte))
+            .await
+            .expect("writer never started writing")
+            .unwrap();
+
+        shutdown_tx.send(true).unwrap();
+
+        wait_for_disconnect(&mut event_rx, &id, 103).await;
+        wait_for_writer_to_close(&write_tx).await;
+    }
 }

--- a/kdeconnect-core/src/transport.rs
+++ b/kdeconnect-core/src/transport.rs
@@ -611,6 +611,8 @@ async fn filtered_identity_for_device(device_id: &str) -> Identity {
         device_type: base.device_type,
         protocol_version: base.protocol_version,
         tcp_port: base.tcp_port,
+        target_device_id: None,
+        target_protocol_version: None,
         incoming_capabilities: base.incoming_capabilities.iter()
             .filter(|c| !remove_inc.contains(c.as_str()))
             .cloned()

--- a/kdeconnect-dbus-client/src/lib.rs
+++ b/kdeconnect-dbus-client/src/lib.rs
@@ -21,6 +21,8 @@ pub struct Device {
     pub id: String,
     pub name: String,
     pub device_type: String,
+    pub incoming_capabilities: Vec<String>,
+    pub outgoing_capabilities: Vec<String>,
     pub is_paired: bool,
     pub is_reachable: bool,
 }
@@ -34,6 +36,7 @@ pub enum ServiceEvent {
     SmsMessagesReceived(String),               // JSON string
     ContactsReceived(HashMap<String, String>), // phone -> name
     PairingRequested(String, String),          // device_id, device_name
+    PairingFinished(String),                   // device_id
     ClipboardReceived(String),                 // clipboard content from phone
     BatteryReceived(String, i32, bool),        // device_id, level, is_charging
     ConnectivityReceived(String, i32),         // device_id, signal_strength
@@ -54,6 +57,7 @@ trait Daemon {
     async fn send_files(&self, device_id: &str, files: Vec<String>) -> zbus::Result<()>;
     async fn send_clipboard(&self, device_id: &str, content: &str) -> zbus::Result<()>;
     async fn ring_device(&self, device_id: &str) -> zbus::Result<()>;
+    async fn browse_device_filesystem(&self, device_id: &str) -> zbus::Result<()>;
     async fn set_plugin_enabled(
         &self,
         device_id: &str,
@@ -69,6 +73,9 @@ trait Daemon {
 
     #[zbus(signal)]
     async fn pairing_requested(&self, device_id: String, device_name: String) -> zbus::Result<()>;
+
+    #[zbus(signal)]
+    async fn pairing_finished(&self, device_id: String) -> zbus::Result<()>;
 
     #[zbus(signal)]
     async fn update_transfer_progress(&self, progress: u8) -> zbus::Result<()>;
@@ -201,6 +208,14 @@ impl KdeConnectClient {
         Ok(self.daemon_proxy.ring_device(device_id).await?)
     }
 
+    /// Request the remote filesystem over SFTP.
+    pub async fn browse_device_filesystem(&self, device_id: &str) -> Result<()> {
+        Ok(self
+            .daemon_proxy
+            .browse_device_filesystem(device_id)
+            .await?)
+    }
+
     /// Enable or disable a plugin for a device
     pub async fn set_plugin_enabled(
         &self,
@@ -255,12 +270,7 @@ impl KdeConnectClient {
     }
 
     /// Send an SMS message
-    pub async fn send_sms(
-        &self,
-        device_id: &str,
-        phone_number: &str,
-        message: &str,
-    ) -> Result<()> {
+    pub async fn send_sms(&self, device_id: &str, phone_number: &str, message: &str) -> Result<()> {
         Ok(self
             .sms_proxy
             .send_sms(device_id, phone_number, message)
@@ -283,144 +293,258 @@ impl KdeConnectClient {
     }
 
     /// Create a stream of service events
-    pub async fn listen_for_events(
-        &self,
-    ) -> futures::stream::BoxStream<'static, ServiceEvent> {
+    pub async fn listen_for_events(&self) -> futures::stream::BoxStream<'static, ServiceEvent> {
         use futures::stream::select_all;
 
         let connected = self
             .daemon_proxy
             .receive_device_connected()
             .await
-            .unwrap()
             .map(|s| {
-                let args = s.args().unwrap();
-                ServiceEvent::DeviceConnected(args.device_id.clone(), args.device.clone())
-            });
+                s.filter_map(|signal| async move {
+                    match signal.args() {
+                        Ok(args) => Some(ServiceEvent::DeviceConnected(
+                            args.device_id.clone(),
+                            args.device.clone(),
+                        )),
+                        Err(e) => {
+                            error!("Failed to parse DeviceConnected signal: {:?}", e);
+                            None
+                        }
+                    }
+                })
+            })
+            .map(|s| Box::pin(s) as futures::stream::BoxStream<'static, ServiceEvent>)
+            .unwrap_or_else(|_| Box::pin(futures::stream::empty()));
 
         let paired = self
             .daemon_proxy
             .receive_device_paired()
             .await
-            .unwrap()
             .map(|s| {
-                let args = s.args().unwrap();
-                ServiceEvent::DevicePaired(args.device_id.clone(), args.device.clone())
-            });
+                s.filter_map(|signal| async move {
+                    match signal.args() {
+                        Ok(args) => Some(ServiceEvent::DevicePaired(
+                            args.device_id.clone(),
+                            args.device.clone(),
+                        )),
+                        Err(e) => {
+                            error!("Failed to parse DevicePaired signal: {:?}", e);
+                            None
+                        }
+                    }
+                })
+            })
+            .map(|s| Box::pin(s) as futures::stream::BoxStream<'static, ServiceEvent>)
+            .unwrap_or_else(|_| Box::pin(futures::stream::empty()));
 
         let disconnected = self
             .daemon_proxy
             .receive_device_disconnected()
             .await
-            .unwrap()
             .map(|s| {
-                let args = s.args().unwrap();
-                ServiceEvent::DeviceDisconnected(args.device_id.clone())
-            });
+                s.filter_map(|signal| async move {
+                    match signal.args() {
+                        Ok(args) => Some(ServiceEvent::DeviceDisconnected(args.device_id.clone())),
+                        Err(e) => {
+                            error!("Failed to parse DeviceDisconnected signal: {:?}", e);
+                            None
+                        }
+                    }
+                })
+            })
+            .map(|s| Box::pin(s) as futures::stream::BoxStream<'static, ServiceEvent>)
+            .unwrap_or_else(|_| Box::pin(futures::stream::empty()));
 
         let sms = self
             .sms_proxy
             .receive_sms_messages_received()
             .await
-            .unwrap()
             .map(|s| {
-                let args = s.args().unwrap();
-                ServiceEvent::SmsMessagesReceived(args.messages_json.clone())
-            });
+                s.filter_map(|signal| async move {
+                    match signal.args() {
+                        Ok(args) => Some(ServiceEvent::SmsMessagesReceived(
+                            args.messages_json.clone(),
+                        )),
+                        Err(e) => {
+                            error!("Failed to parse SMS signal: {:?}", e);
+                            None
+                        }
+                    }
+                })
+            })
+            .map(|s| Box::pin(s) as futures::stream::BoxStream<'static, ServiceEvent>)
+            .unwrap_or_else(|_| Box::pin(futures::stream::empty()));
 
         let contacts = self
             .contacts_proxy
             .receive_contacts_received()
             .await
-            .unwrap()
             .map(|s| {
-                let args = s.args().unwrap();
-                let contacts_json = args.contacts_json.clone();
-                let map: HashMap<String, String> =
-                    serde_json::from_str(&contacts_json).unwrap_or_default();
-                ServiceEvent::ContactsReceived(map)
-            });
+                s.filter_map(|signal| async move {
+                    match signal.args() {
+                        Ok(args) => {
+                            let contacts_json = args.contacts_json.clone();
+                            let map: HashMap<String, String> =
+                                serde_json::from_str(&contacts_json).unwrap_or_default();
+                            Some(ServiceEvent::ContactsReceived(map))
+                        }
+                        Err(e) => {
+                            error!("Failed to parse Contacts signal: {:?}", e);
+                            None
+                        }
+                    }
+                })
+            })
+            .map(|s| Box::pin(s) as futures::stream::BoxStream<'static, ServiceEvent>)
+            .unwrap_or_else(|_| Box::pin(futures::stream::empty()));
 
         let pairing_req = self
             .daemon_proxy
             .receive_pairing_requested()
             .await
-            .unwrap()
             .map(|s| {
-                let args = s.args().unwrap();
-                ServiceEvent::PairingRequested(
-                    args.device_id.clone(),
-                    args.device_name.clone(),
-                )
-            });
+                s.filter_map(|signal| async move {
+                    match signal.args() {
+                        Ok(args) => Some(ServiceEvent::PairingRequested(
+                            args.device_id.clone(),
+                            args.device_name.clone(),
+                        )),
+                        Err(e) => {
+                            error!("Failed to parse PairingRequested signal: {:?}", e);
+                            None
+                        }
+                    }
+                })
+            })
+            .map(|s| Box::pin(s) as futures::stream::BoxStream<'static, ServiceEvent>)
+            .unwrap_or_else(|_| Box::pin(futures::stream::empty()));
+
+        let pairing_finished = self
+            .daemon_proxy
+            .receive_pairing_finished()
+            .await
+            .map(|s| {
+                s.filter_map(|signal| async move {
+                    match signal.args() {
+                        Ok(args) => Some(ServiceEvent::PairingFinished(args.device_id.clone())),
+                        Err(e) => {
+                            error!("Failed to parse PairingFinished signal: {:?}", e);
+                            None
+                        }
+                    }
+                })
+            })
+            .map(|s| Box::pin(s) as futures::stream::BoxStream<'static, ServiceEvent>)
+            .unwrap_or_else(|_| Box::pin(futures::stream::empty()));
 
         let clipboard = self
             .daemon_proxy
             .receive_clipboard_received()
             .await
-            .unwrap()
             .map(|s| {
-                let args = s.args().unwrap();
-                ServiceEvent::ClipboardReceived(args.content.clone())
-            });
+                s.filter_map(|signal| async move {
+                    match signal.args() {
+                        Ok(args) => Some(ServiceEvent::ClipboardReceived(args.content.clone())),
+                        Err(e) => {
+                            error!("Failed to parse Clipboard signal: {:?}", e);
+                            None
+                        }
+                    }
+                })
+            })
+            .map(|s| Box::pin(s) as futures::stream::BoxStream<'static, ServiceEvent>)
+            .unwrap_or_else(|_| Box::pin(futures::stream::empty()));
 
         let battery = self
             .daemon_proxy
             .receive_battery_received()
             .await
-            .unwrap()
             .map(|s| {
-                let args = s.args().unwrap();
-                ServiceEvent::BatteryReceived(
-                    args.device_id.clone(),
-                    args.level,
-                    args.is_charging,
-                )
-            });
+                s.filter_map(|signal| async move {
+                    match signal.args() {
+                        Ok(args) => Some(ServiceEvent::BatteryReceived(
+                            args.device_id.clone(),
+                            args.level,
+                            args.is_charging,
+                        )),
+                        Err(e) => {
+                            error!("Failed to parse Battery signal: {:?}", e);
+                            None
+                        }
+                    }
+                })
+            })
+            .map(|s| Box::pin(s) as futures::stream::BoxStream<'static, ServiceEvent>)
+            .unwrap_or_else(|_| Box::pin(futures::stream::empty()));
 
         let connectivity = self
             .daemon_proxy
             .receive_connectivity_received()
             .await
-            .unwrap()
             .map(|s| {
-                let args = s.args().unwrap();
-                ServiceEvent::ConnectivityReceived(args.device_id.clone(), args.signal_strength)
-            });
+                s.filter_map(|signal| async move {
+                    match signal.args() {
+                        Ok(args) => Some(ServiceEvent::ConnectivityReceived(
+                            args.device_id.clone(),
+                            args.signal_strength,
+                        )),
+                        Err(e) => {
+                            error!("Failed to parse Connectivity signal: {:?}", e);
+                            None
+                        }
+                    }
+                })
+            })
+            .map(|s| Box::pin(s) as futures::stream::BoxStream<'static, ServiceEvent>)
+            .unwrap_or_else(|_| Box::pin(futures::stream::empty()));
 
         let run_command_list = self
             .daemon_proxy
             .receive_run_command_list_received()
             .await
-            .unwrap()
             .map(|s| {
-                let args = s.args().unwrap();
-                ServiceEvent::RunCommandListReceived(
-                    args.device_id.clone(),
-                    args.commands_json.clone(),
-                )
-            });
+                s.filter_map(|signal| async move {
+                    match signal.args() {
+                        Ok(args) => Some(ServiceEvent::RunCommandListReceived(
+                            args.device_id.clone(),
+                            args.commands_json.clone(),
+                        )),
+                        Err(e) => {
+                            error!("Failed to parse RunCommandList signal: {:?}", e);
+                            None
+                        }
+                    }
+                })
+            })
+            .map(|s| Box::pin(s) as futures::stream::BoxStream<'static, ServiceEvent>)
+            .unwrap_or_else(|_| Box::pin(futures::stream::empty()));
 
         Box::pin(select_all(vec![
-            Box::pin(connected) as futures::stream::BoxStream<'static, ServiceEvent>,
-            Box::pin(paired),
-            Box::pin(disconnected),
-            Box::pin(sms),
-            Box::pin(contacts),
-            Box::pin(pairing_req),
-            Box::pin(clipboard),
-            Box::pin(battery),
-            Box::pin(connectivity),
-            Box::pin(run_command_list),
+            connected,
+            paired,
+            disconnected,
+            sms,
+            contacts,
+            pairing_req,
+            pairing_finished,
+            clipboard,
+            battery,
+            connectivity,
+            run_command_list,
         ]))
     }
 
     pub async fn transfer_progress_stream(&self) -> impl futures::stream::Stream<Item = u8> {
-        let daemon_update_transfer_progress = self
-            .daemon_proxy
-            .receive_update_transfer_progress()
-            .await
-            .unwrap();
+        let daemon_update_transfer_progress =
+            match self.daemon_proxy.receive_update_transfer_progress().await {
+                Ok(s) => s,
+                Err(e) => {
+                    error!("Failed to subscribe to transfer progress: {:?}", e);
+                    return Box::pin(futures::stream::empty())
+                        as futures::stream::BoxStream<'static, u8>;
+                }
+            };
 
         let update_transfer_stream =
             daemon_update_transfer_progress.filter_map(|signal| async move {
@@ -433,8 +557,6 @@ impl KdeConnectClient {
                 }
             });
 
-        let result = Box::pin(update_transfer_stream);
-
-        futures::stream::select_all(vec![result])
+        Box::pin(update_transfer_stream)
     }
 }

--- a/kdeconnect-service/src/dbus_interface.rs
+++ b/kdeconnect-service/src/dbus_interface.rs
@@ -3,7 +3,8 @@
 use anyhow::Result;
 use kdeconnect_core::{
     KdeConnectCore, PacketType, ProtocolPacket,
-    device::{DeviceId, DeviceState, PairState},
+    config::CONFIG_DIR,
+    device::{Device as CoreDevice, DeviceId, DeviceState, PairState},
     event::{AppEvent, ConnectionEvent},
 };
 use serde::{Deserialize, Serialize};
@@ -34,6 +35,8 @@ pub struct DbusDevice {
     pub id: String,
     pub name: String,
     pub device_type: String,
+    pub incoming_capabilities: Vec<String>,
+    pub outgoing_capabilities: Vec<String>,
     pub is_paired: bool,
     pub is_reachable: bool,
 }
@@ -41,7 +44,9 @@ pub struct DbusDevice {
 // --- Per-device cache helpers ------------------------------------------------
 
 fn device_cache_dir(device_id: &str) -> std::path::PathBuf {
-    let base = dirs::data_local_dir().unwrap_or_else(|| std::path::PathBuf::from("~/.local/share"));
+    let base = dirs::data_local_dir()
+        .or_else(|| dirs::home_dir().map(|h| h.join(".local").join("share")))
+        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
     base.join("kdeconnect").join(device_id)
 }
 
@@ -115,7 +120,96 @@ async fn load_sms_cache(device_id: &str) -> Option<String> {
     }
 }
 
+fn dbus_device_from_core(device: &CoreDevice, is_reachable: bool) -> DbusDevice {
+    DbusDevice {
+        id: device.device_id.0.clone(),
+        name: device.name.clone(),
+        device_type: device.device_type.clone(),
+        incoming_capabilities: device.incoming_capabilities.clone(),
+        outgoing_capabilities: device.outgoing_capabilities.clone(),
+        is_paired: true,
+        is_reachable,
+    }
+}
+
+async fn load_persisted_paired_device(device_id: &str) -> Option<CoreDevice> {
+    let path = dirs::config_dir()?
+        .join(CONFIG_DIR)
+        .join(format!("{device_id}.ron"));
+    let raw = tokio::fs::read_to_string(path).await.ok()?;
+    let device = ron::de::from_str::<CoreDevice>(&raw).ok()?;
+    (device.pair_state == PairState::Paired).then_some(device)
+}
+
+async fn load_persisted_paired_devices() -> Vec<CoreDevice> {
+    let Some(config_dir) = dirs::config_dir() else {
+        return Vec::new();
+    };
+    let kc_dir = config_dir.join(CONFIG_DIR);
+    let Ok(mut entries) = tokio::fs::read_dir(&kc_dir).await else {
+        return Vec::new();
+    };
+
+    let mut devices = Vec::new();
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("ron") {
+            continue;
+        }
+        if let Ok(raw) = tokio::fs::read_to_string(&path).await
+            && let Ok(device) = ron::de::from_str::<CoreDevice>(&raw)
+            && device.pair_state == PairState::Paired
+        {
+            devices.push(device);
+        }
+    }
+    devices
+}
+
+async fn reconcile_persisted_pair_state(devices: &Arc<Mutex<HashMap<String, DbusDevice>>>) {
+    let persisted_devices = load_persisted_paired_devices().await;
+    if persisted_devices.is_empty() {
+        return;
+    }
+
+    let mut map = devices.lock().await;
+    for device in persisted_devices {
+        let reachable = map
+            .get(&device.device_id.0)
+            .map(|device| device.is_reachable)
+            .unwrap_or(false);
+        map.insert(
+            device.device_id.0.clone(),
+            dbus_device_from_core(&device, reachable),
+        );
+    }
+}
+
 // ----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sms_conversation_request_uses_gsconnect_thread_id_shape() {
+        assert_eq!(sms_conversation_request_body(42), json!({ "threadID": 42 }));
+    }
+
+    #[test]
+    fn sms_send_request_includes_modern_and_legacy_android_payloads() {
+        assert_eq!(
+            sms_send_request_body("555-555-5555", "message body"),
+            json!({
+                "addresses": [{ "address": "555-555-5555" }],
+                "version": 2,
+                "sendSms": true,
+                "phoneNumber": "555-555-5555",
+                "messageBody": "message body",
+            })
+        );
+    }
+}
 
 /// Main daemon D-Bus interface
 pub struct DaemonInterface {
@@ -128,6 +222,7 @@ impl DaemonInterface {
     /// List all known devices
     async fn list_devices(&self) -> Vec<DbusDevice> {
         info!("D-Bus: ListDevices called");
+        reconcile_persisted_pair_state(&self.devices).await;
         let devices = self.devices.lock().await;
         let device_list: Vec<DbusDevice> = devices.values().cloned().collect();
         info!("D-Bus: Returning {} devices", device_list.len());
@@ -144,11 +239,32 @@ impl DaemonInterface {
     }
 
     /// Unpair from a device
-    async fn unpair_device(&self, device_id: String) -> zbus::fdo::Result<()> {
+    async fn unpair_device(
+        &self,
+        #[zbus(signal_emitter)] signal_emitter: SignalEmitter<'_>,
+        device_id: String,
+    ) -> zbus::fdo::Result<()> {
         info!("D-Bus: UnpairDevice called for {}", device_id);
         self.event_sender
-            .send(AppEvent::Unpair(DeviceId(device_id)))
+            .send(AppEvent::Unpair(DeviceId(device_id.clone())))
             .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
+
+        let updated_device = {
+            let mut devices = self.devices.lock().await;
+            if let Some(device) = devices.get_mut(&device_id) {
+                device.is_paired = false;
+                Some(device.clone())
+            } else {
+                None
+            }
+        };
+
+        if let Some(device) = updated_device {
+            DaemonInterface::device_connected(&signal_emitter, device_id, device)
+                .await
+                .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
+        }
+
         Ok(())
     }
 
@@ -158,9 +274,8 @@ impl DaemonInterface {
             "D-Bus: SendPing called for {} with message: {}",
             device_id, message
         );
-        let packet = ProtocolPacket::new(PacketType::Ping, json!({ "message": message }));
         self.event_sender
-            .send(AppEvent::SendPacket(DeviceId(device_id), packet))
+            .send(AppEvent::Ping((DeviceId(device_id), message)))
             .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
         Ok(())
     }
@@ -181,7 +296,16 @@ impl DaemonInterface {
     /// Send clipboard content
     async fn send_clipboard(&self, device_id: String, content: String) -> zbus::fdo::Result<()> {
         info!("D-Bus: SendClipboard called for {}", device_id);
-        let packet = ProtocolPacket::new(PacketType::Clipboard, json!({ "content": content }));
+        let packet = ProtocolPacket::new(
+            PacketType::Clipboard,
+            json!({
+                "content": content,
+                "timestamp": std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as u64
+            }),
+        );
         self.event_sender
             .send(AppEvent::SendPacket(DeviceId(device_id), packet))
             .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
@@ -192,6 +316,16 @@ impl DaemonInterface {
     async fn ring_device(&self, device_id: String) -> zbus::fdo::Result<()> {
         info!("D-Bus: RingDevice called for {}", device_id);
         let packet = ProtocolPacket::new(PacketType::FindMyPhoneRequest, json!({}));
+        self.event_sender
+            .send(AppEvent::SendPacket(DeviceId(device_id), packet))
+            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Request the remote filesystem over SFTP.
+    async fn browse_device_filesystem(&self, device_id: String) -> zbus::fdo::Result<()> {
+        info!("D-Bus: BrowseDeviceFilesystem called for {}", device_id);
+        let packet = ProtocolPacket::new(PacketType::SftpRequest, json!({ "startBrowsing": true }));
         self.event_sender
             .send(AppEvent::SendPacket(DeviceId(device_id), packet))
             .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
@@ -222,14 +356,10 @@ impl DaemonInterface {
 
     /// Return the list of disabled plugin IDs for a device.
     async fn get_disabled_plugins(&self, device_id: String) -> Vec<String> {
-        let path = dirs::config_dir()
-            .unwrap_or_else(|| std::path::PathBuf::from("~/.config"))
-            .join("kdeconnect")
-            .join(format!("{}_plugins.json", device_id));
-        match tokio::fs::read_to_string(&path).await {
-            Ok(json) => serde_json::from_str::<Vec<String>>(&json).unwrap_or_default(),
-            Err(_) => vec![],
-        }
+        kdeconnect_core::plugin_config::load_disabled_plugins(&device_id)
+            .await
+            .into_iter()
+            .collect()
     }
 
     /// Trigger a UDP identity broadcast to discover nearby devices.
@@ -245,7 +375,9 @@ impl DaemonInterface {
     async fn accept_pairing(&self, device_id: String) -> zbus::fdo::Result<()> {
         info!("D-Bus: AcceptPairing called for {}", device_id);
         self.event_sender
-            .send(AppEvent::AcceptPairing(kdeconnect_core::device::DeviceId(device_id)))
+            .send(AppEvent::AcceptPairing(kdeconnect_core::device::DeviceId(
+                device_id,
+            )))
             .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
         Ok(())
     }
@@ -254,7 +386,9 @@ impl DaemonInterface {
     async fn reject_pairing(&self, device_id: String) -> zbus::fdo::Result<()> {
         info!("D-Bus: RejectPairing called for {}", device_id);
         self.event_sender
-            .send(AppEvent::RejectPairing(kdeconnect_core::device::DeviceId(device_id)))
+            .send(AppEvent::RejectPairing(kdeconnect_core::device::DeviceId(
+                device_id,
+            )))
             .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
         Ok(())
     }
@@ -265,6 +399,13 @@ impl DaemonInterface {
         signal_emitter: &SignalEmitter<'_>,
         device_id: String,
         device_name: String,
+    ) -> zbus::Result<()>;
+
+    /// Signal: A pairing request finished, failed, or is no longer actionable.
+    #[zbus(signal)]
+    async fn pairing_finished(
+        signal_emitter: &SignalEmitter<'_>,
+        device_id: String,
     ) -> zbus::Result<()>;
 
     /// Signal: Device connected
@@ -323,10 +464,7 @@ impl DaemonInterface {
     /// Execute a remote command on a device by key
     async fn run_command(&self, device_id: String, key: String) -> zbus::fdo::Result<()> {
         info!("D-Bus: RunCommand called for {} key={}", device_id, key);
-        let packet = ProtocolPacket::new(
-            PacketType::RunCommandRequest,
-            json!({ "key": key }),
-        );
+        let packet = ProtocolPacket::new(PacketType::RunCommandRequest, json!({ "key": key }));
         self.event_sender
             .send(AppEvent::SendPacket(DeviceId(device_id), packet))
             .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
@@ -364,6 +502,20 @@ pub struct SmsInterface {
     current_device_id: Arc<Mutex<Option<String>>>,
 }
 
+fn sms_conversation_request_body(thread_id: i64) -> serde_json::Value {
+    json!({ "threadID": thread_id })
+}
+
+fn sms_send_request_body(phone_number: &str, message: &str) -> serde_json::Value {
+    json!({
+        "addresses": [{ "address": phone_number }],
+        "version": 2,
+        "sendSms": true,
+        "phoneNumber": phone_number,
+        "messageBody": message,
+    })
+}
+
 #[interface(name = "io.github.hepp3n.kdeconnect.Sms")]
 impl SmsInterface {
     /// Return cached SMS JSON — in-memory first, disk fallback, empty if neither
@@ -372,10 +524,7 @@ impl SmsInterface {
             debug!("Returning in-memory SMS cache ({} bytes)", json.len());
             return json.clone();
         }
-        match load_sms_cache(&device_id).await {
-            Some(json) => json,
-            None => String::new(),
-        }
+        load_sms_cache(&device_id).await.unwrap_or_default()
     }
 
     /// Request all conversations from device
@@ -404,7 +553,7 @@ impl SmsInterface {
         );
         let packet = ProtocolPacket::new(
             PacketType::SmsRequestConversation,
-            json!({ "threadID": thread_id }),
+            sms_conversation_request_body(thread_id),
         );
         self.event_sender
             .send(AppEvent::SendPacket(DeviceId(device_id), packet))
@@ -429,12 +578,7 @@ impl SmsInterface {
         );
         let packet = ProtocolPacket::new(
             PacketType::SmsRequest,
-            json!({
-                "sendSms": true,
-                "addresses": [{ "address": phone_number }],
-                "messageBody": message,
-                "version": 2
-            }),
+            sms_send_request_body(&phone_number, &message),
         );
         self.event_sender
             .send(AppEvent::SendPacket(DeviceId(device_id), packet))
@@ -540,12 +684,6 @@ impl KdeConnectService {
     pub async fn new() -> Result<Self> {
         info!("Initializing KDE Connect D-Bus service");
 
-        let connection = Connection::session().await?;
-        info!("D-Bus session connection established");
-
-        connection.request_name(SERVICE_NAME).await?;
-        info!("D-Bus service name '{}' registered", SERVICE_NAME);
-
         info!("Initializing kdeconnect-core");
         let (mut core, mut event_receiver) = KdeConnectCore::new().await?;
         let event_sender = core.take_events();
@@ -556,34 +694,10 @@ impl KdeConnectService {
         // Pre-populate known paired devices as offline so list_devices() returns
         // them immediately after reboot, before the phone actively reconnects.
         {
-            use kdeconnect_core::{config::CONFIG_DIR, device::Device as CoreDevice};
             let mut map = devices.lock().await;
-            if let Some(config_dir) = dirs::config_dir() {
-                let kc_dir = config_dir.join(CONFIG_DIR);
-                if let Ok(mut entries) = tokio::fs::read_dir(&kc_dir).await {
-                    while let Ok(Some(entry)) = entries.next_entry().await {
-                        let path = entry.path();
-                        if path.extension().and_then(|e| e.to_str()) == Some("ron") {
-                            if let Ok(raw) = tokio::fs::read_to_string(&path).await {
-                                if let Ok(dev) = ron::de::from_str::<CoreDevice>(&raw) {
-                                    if dev.pair_state == PairState::Paired {
-                                        info!("Restoring offline paired device: {}", dev.name);
-                                        map.insert(
-                                            dev.device_id.0.clone(),
-                                            DbusDevice {
-                                                id: dev.device_id.0.clone(),
-                                                name: dev.name.clone(),
-                                                device_type: "phone".to_string(),
-                                                is_paired: true,
-                                                is_reachable: false,
-                                            },
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+            for dev in load_persisted_paired_devices().await {
+                info!("Restoring offline paired device: {}", dev.name);
+                map.insert(dev.device_id.0.clone(), dbus_device_from_core(&dev, false));
             }
         }
 
@@ -591,11 +705,6 @@ impl KdeConnectService {
             event_sender: event_sender.clone(),
             devices: devices.clone(),
         };
-        connection
-            .object_server()
-            .at(DAEMON_PATH, daemon_interface)
-            .await?;
-        info!("Daemon interface registered at {}", DAEMON_PATH);
 
         let sms_cache: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
         let current_device_id: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
@@ -605,24 +714,26 @@ impl KdeConnectService {
             sms_cache: sms_cache.clone(),
             current_device_id: current_device_id.clone(),
         };
-        connection
-            .object_server()
-            .at(SMS_PATH, sms_interface)
-            .await?;
-        info!("SMS interface registered at {}", SMS_PATH);
 
         let contacts_interface = ContactsInterface {
             event_sender: event_sender.clone(),
         };
-        connection
-            .object_server()
-            .at(CONTACTS_PATH, contacts_interface)
+
+        let connection = zbus::connection::Builder::session()?
+            .serve_at(DAEMON_PATH, daemon_interface)?
+            .serve_at(SMS_PATH, sms_interface)?
+            .serve_at(CONTACTS_PATH, contacts_interface)?
+            .name(SERVICE_NAME)?
+            .build()
             .await?;
+        info!("D-Bus session connection established");
+        info!("D-Bus service name '{}' registered", SERVICE_NAME);
+        info!("Daemon interface registered at {}", DAEMON_PATH);
+        info!("SMS interface registered at {}", SMS_PATH);
         info!("Contacts interface registered at {}", CONTACTS_PATH);
 
         let conn_clone = connection.clone();
         let devices_clone = devices.clone();
-        let event_sender_clone = event_sender.clone();
         let sms_synced: SmsSyncedSet = Arc::new(Mutex::new(std::collections::HashSet::new()));
 
         tokio::spawn(async move {
@@ -632,7 +743,6 @@ impl KdeConnectService {
                     &conn_clone,
                     event,
                     &devices_clone,
-                    &event_sender_clone,
                     &sms_cache,
                     &current_device_id,
                     &sms_synced,
@@ -651,7 +761,9 @@ impl KdeConnectService {
         tokio::spawn(async move {
             match core_handle.await {
                 Ok(_) => error!("Core event loop exited unexpectedly - connections will fail"),
-                Err(e) if e.is_panic() => error!("Core event loop PANICKED - connections will fail: {:?}", e),
+                Err(e) if e.is_panic() => {
+                    error!("Core event loop PANICKED - connections will fail: {:?}", e)
+                }
                 Err(e) => error!("Core event loop cancelled: {:?}", e),
             }
         });
@@ -667,7 +779,6 @@ impl KdeConnectService {
         connection: &Connection,
         event: ConnectionEvent,
         devices: &Arc<Mutex<HashMap<String, DbusDevice>>>,
-        event_sender: &Arc<mpsc::UnboundedSender<AppEvent>>,
         sms_cache: &Arc<Mutex<Option<String>>>,
         current_device_id: &Arc<Mutex<Option<String>>>,
         sms_synced: &SmsSyncedSet,
@@ -682,7 +793,9 @@ impl KdeConnectService {
                 let dbus_device = DbusDevice {
                     id: device_id.0.clone(),
                     name: device.name.clone(),
-                    device_type: "phone".to_string(),
+                    device_type: device.device_type.clone(),
+                    incoming_capabilities: device.incoming_capabilities.clone(),
+                    outgoing_capabilities: device.outgoing_capabilities.clone(),
                     is_paired,
                     is_reachable: true,
                 };
@@ -708,29 +821,29 @@ impl KdeConnectService {
                 if is_paired {
                     let did = device_id.0.clone();
 
-                    if let Some(cached) = load_contacts_cache(&did).await {
-                        if let Ok(contacts_json) = serde_json::to_string(&cached) {
-                            let iface_ref = connection
-                                .object_server()
-                                .interface::<_, ContactsInterface>(CONTACTS_PATH)
-                                .await?;
-                            ContactsInterface::contacts_received(
-                                iface_ref.signal_emitter(),
-                                contacts_json,
-                            )
+                    if let Some(cached) = load_contacts_cache(&did).await
+                        && let Ok(contacts_json) = serde_json::to_string(&cached)
+                    {
+                        let iface_ref = connection
+                            .object_server()
+                            .interface::<_, ContactsInterface>(CONTACTS_PATH)
                             .await?;
-                            debug!(
-                                "Emitted cached contacts on connect ({} entries)",
-                                cached.len()
-                            );
-                        }
+                        ContactsInterface::contacts_received(
+                            iface_ref.signal_emitter(),
+                            contacts_json,
+                        )
+                        .await?;
+                        debug!(
+                            "Emitted cached contacts on connect ({} entries)",
+                            cached.len()
+                        );
                     }
 
-                    if sms_cache.lock().await.is_none() {
-                        if let Some(cached_sms) = load_sms_cache(&did).await {
-                            *sms_cache.lock().await = Some(cached_sms);
-                            debug!("Seeded in-memory SMS cache from disk on connect");
-                        }
+                    if sms_cache.lock().await.is_none()
+                        && let Some(cached_sms) = load_sms_cache(&did).await
+                    {
+                        *sms_cache.lock().await = Some(cached_sms);
+                        debug!("Seeded in-memory SMS cache from disk on connect");
                     }
 
                     let already_synced = sms_synced.lock().await.contains(&device_id.0);
@@ -750,7 +863,9 @@ impl KdeConnectService {
                 let dbus_device = DbusDevice {
                     id: device_id.0.clone(),
                     name: device.name.clone(),
-                    device_type: "phone".to_string(),
+                    device_type: device.device_type.clone(),
+                    incoming_capabilities: device.incoming_capabilities.clone(),
+                    outgoing_capabilities: device.outgoing_capabilities.clone(),
                     is_paired: true,
                     is_reachable: true,
                 };
@@ -771,25 +886,12 @@ impl KdeConnectService {
                     dbus_device,
                 )
                 .await?;
+                DaemonInterface::pairing_finished(iface_ref.signal_emitter(), device_id.0.clone())
+                    .await?;
                 debug!("Device paired signal emitted");
 
-                let sender = event_sender.clone();
-                let did = device_id.0.clone();
-                tokio::spawn(async move {
-                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                    let sms_packet =
-                        ProtocolPacket::new(PacketType::SmsRequestConversations, json!({}));
-                    let _ = sender.send(AppEvent::SendPacket(DeviceId(did.clone()), sms_packet));
-                    debug!("Auto-requested SMS conversations after pairing");
-
-                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                    let contacts_packet = ProtocolPacket::new(
-                        PacketType::ContactsRequestAllUidsTimestamps,
-                        json!({}),
-                    );
-                    let _ = sender.send(AppEvent::SendPacket(DeviceId(did), contacts_packet));
-                    debug!("Auto-requested contacts after pairing");
-                });
+                // Initial plugin sync is handled in kdeconnect-core, where it can
+                // respect per-device plugin enablement before sending packets.
             }
             ConnectionEvent::Disconnected(device_id) => {
                 info!("Device disconnected: {}", device_id.0);
@@ -820,13 +922,18 @@ impl KdeConnectService {
                 debug!("Device disconnected signal emitted");
             }
             ConnectionEvent::PairStateChanged((device_id, pair_state)) => {
-                info!("Event: PairStateChanged - {} → {:?}", device_id.0, pair_state);
-                let is_paired = matches!(pair_state, PairState::Paired);
-
+                info!(
+                    "Event: PairStateChanged - {} → {:?}",
+                    device_id.0, pair_state
+                );
                 {
                     let mut map = devices.lock().await;
                     if let Some(dev) = map.get_mut(&device_id.0) {
-                        dev.is_paired = is_paired;
+                        match pair_state {
+                            PairState::Paired => dev.is_paired = true,
+                            PairState::NotPaired => dev.is_paired = false,
+                            PairState::Requesting | PairState::Requested => {}
+                        }
                     }
                 }
 
@@ -844,6 +951,13 @@ impl KdeConnectService {
                     )
                     .await?;
                 }
+                if matches!(pair_state, PairState::NotPaired | PairState::Paired) {
+                    DaemonInterface::pairing_finished(
+                        iface_ref.signal_emitter(),
+                        device_id.0.clone(),
+                    )
+                    .await?;
+                }
                 debug!("PairStateChanged signal emitted for {}", device_id.0);
             }
             ConnectionEvent::SmsMessages(sms_data) => {
@@ -857,7 +971,9 @@ impl KdeConnectService {
 
                 *sms_cache.lock().await = Some(messages_json.clone());
 
-                if let Some(did) = current_device_id.lock().await.as_deref() {
+                if let Some(did) = sms_data.device_id.as_deref() {
+                    save_sms_cache(did, &messages_json).await;
+                } else if let Some(did) = current_device_id.lock().await.as_deref() {
                     save_sms_cache(did, &messages_json).await;
                 }
 
@@ -870,12 +986,10 @@ impl KdeConnectService {
                     .await?;
                 debug!("SMS D-Bus signal emitted");
             }
-            ConnectionEvent::ContactsReceived(contacts) => {
+            ConnectionEvent::ContactsReceived(device_id, contacts) => {
                 info!("Contacts received: {} entries", contacts.len());
 
-                if let Some(did) = current_device_id.lock().await.as_deref() {
-                    save_contacts_cache(did, &contacts).await;
-                }
+                save_contacts_cache(&device_id.0, &contacts).await;
 
                 let contacts_json = serde_json::to_string(&contacts)?;
 
@@ -919,6 +1033,50 @@ impl KdeConnectService {
                 // The D-Bus signal is the primary mechanism — the applet
                 // subscription delivers it immediately and opens the popup.
             }
+            ConnectionEvent::PairingTimedOut(device_id) => {
+                info!("Pairing timed out for {}", device_id.0);
+                // Update the device to reflect the unpaired state and emit a
+                // device_connected signal so the applet refreshes immediately.
+                let persisted_paired = load_persisted_paired_device(&device_id.0).await;
+                {
+                    let mut map = devices.lock().await;
+                    if let Some(device) = persisted_paired {
+                        let reachable = map
+                            .get(&device_id.0)
+                            .map(|device| device.is_reachable)
+                            .unwrap_or(false);
+                        map.insert(
+                            device_id.0.clone(),
+                            dbus_device_from_core(&device, reachable),
+                        );
+                    } else if let Some(dev) = map.get_mut(&device_id.0) {
+                        dev.is_paired = false;
+                    }
+                }
+                let iface_ref = connection
+                    .object_server()
+                    .interface::<_, DaemonInterface>(DAEMON_PATH)
+                    .await?;
+                if let Some(dev) = devices.lock().await.get(&device_id.0).cloned() {
+                    DaemonInterface::device_connected(
+                        iface_ref.signal_emitter(),
+                        device_id.0.clone(),
+                        dev,
+                    )
+                    .await?;
+                }
+                DaemonInterface::pairing_finished(iface_ref.signal_emitter(), device_id.0.clone())
+                    .await?;
+                debug!("PairingTimedOut signal emitted for {}", device_id.0);
+            }
+            ConnectionEvent::PairingFinished(device_id) => {
+                let iface_ref = connection
+                    .object_server()
+                    .interface::<_, DaemonInterface>(DAEMON_PATH)
+                    .await?;
+                DaemonInterface::pairing_finished(iface_ref.signal_emitter(), device_id.0).await?;
+                debug!("PairingFinished D-Bus signal emitted");
+            }
             ConnectionEvent::ClipboardReceived(content) => {
                 info!("Clipboard received ({} bytes)", content.len());
 
@@ -926,18 +1084,10 @@ impl KdeConnectService {
                     .object_server()
                     .interface::<_, DaemonInterface>(DAEMON_PATH)
                     .await?;
-                DaemonInterface::clipboard_received(iface_ref.signal_emitter(), content)
-                    .await?;
+                DaemonInterface::clipboard_received(iface_ref.signal_emitter(), content).await?;
                 debug!("ClipboardReceived D-Bus signal emitted");
             }
-            ConnectionEvent::StateUpdated(state) => {
-                let device_id = match current_device_id.lock().await.clone() {
-                    Some(id) => id,
-                    None => {
-                        debug!("StateUpdated but no current device id");
-                        return Ok(());
-                    }
-                };
+            ConnectionEvent::StateUpdated((device_id, state)) => {
                 let iface_ref = connection
                     .object_server()
                     .interface::<_, DaemonInterface>(DAEMON_PATH)
@@ -946,8 +1096,8 @@ impl KdeConnectService {
                     DeviceState::Battery { level, charging } => {
                         DaemonInterface::battery_received(
                             iface_ref.signal_emitter(),
-                            device_id,
-                            level as i32,
+                            device_id.0,
+                            level,
                             charging,
                         )
                         .await?;
@@ -956,7 +1106,7 @@ impl KdeConnectService {
                     DeviceState::Connectivity((_, signal_strength)) => {
                         DaemonInterface::connectivity_received(
                             iface_ref.signal_emitter(),
-                            device_id,
+                            device_id.0,
                             signal_strength,
                         )
                         .await?;

--- a/kdeconnect-service/src/main.rs
+++ b/kdeconnect-service/src/main.rs
@@ -16,33 +16,19 @@ async fn main() -> Result<()> {
 
     info!("KDE Connect service starting");
 
-    // Single-instance guard: request the well-known D-Bus name before touching
-    // any sockets or config files. DoNotQueue means a second instance exits
-    // immediately rather than racing on port binding or cert/key generation.
-    // The connection is scoped so it drops (releasing the name) before
-    // KdeConnectService::new() acquires it on its own connection — otherwise
-    // the two request_name calls on different connections would deadlock.
+    // Single-instance guard: check the bus name before touching sockets or
+    // config files. The service connection below owns the name after its D-Bus
+    // objects are registered, which avoids zbus' request-before-serve warning.
     {
         let guard_conn = zbus::Connection::session().await?;
-        match guard_conn
-            .request_name_with_flags(
-                "io.github.hepp3n.kdeconnect",
-                zbus::fdo::RequestNameFlags::DoNotQueue.into(),
-            )
-            .await
-        {
-            Ok(zbus::fdo::RequestNameReply::PrimaryOwner) => {
-                info!("Single-instance guard passed");
-            }
-            Ok(_) => {
-                info!("Another instance is already running — exiting");
-                return Ok(());
-            }
-            Err(e) => {
-                return Err(e.into());
-            }
+        let dbus = zbus::fdo::DBusProxy::new(&guard_conn).await?;
+        let service_name = zbus::names::BusName::try_from("io.github.hepp3n.kdeconnect")?;
+        if dbus.name_has_owner(service_name).await? {
+            info!("Another instance is already running — exiting");
+            return Ok(());
         }
-    } // guard_conn drops here, name is released for KdeConnectService::new()
+        info!("Single-instance guard passed");
+    }
 
     let service = dbus_interface::KdeConnectService::new().await?;
     info!("D-Bus service started on io.github.hepp3n.kdeconnect");

--- a/resources/99-uinput.rules
+++ b/resources/99-uinput.rules
@@ -1,0 +1,1 @@
+KERNEL=="uinput", MODE="0660", GROUP="input"

--- a/resources/ydotoold.service
+++ b/resources/ydotoold.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=ydotool daemon for COSMIC KDE Connect remote input
+Documentation=man:ydotool(1)
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/ydotoold --socket-path=%t/.ydotool_socket --socket-perm=0600
+Restart=on-failure
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary
Updates notification, share, run-command, and telephony handlers so they fit the revised dispatch and capability model, including non-blocking notification behavior and safer share handling.

## Maintainer Review Notes
This is the remaining core plugin behavior needed before the central event loop is switched to the extracted helper path.

## Stack Note
This PR targets `cosmic-utils:master` because I do not have permission to create the intermediate stack base branches in `cosmic-utils/kdeconnect`.

The intended incremental review base is `PR1-core-5-input-media-plugins`, and this branch was verified against that base. After the earlier PRs in the stack are merged, GitHub will naturally narrow this PR's visible diff to the focused change described here.

## Stack
Upstream PR base: `master`  
Intended incremental base: `PR1-core-5-input-media-plugins`  
Head: `JaredTweed:PR1-core-6-plugin-handlers`

## Verification
This branch was checked against its intended incremental base with:

- `git diff --check PR1-core-5-input-media-plugins..PR1-core-6-plugin-handlers`
- `cargo check --workspace`
- `cargo test -p kdeconnect-core`
