### PR TITLE
fix: (command plugin) persist commands across sessions and fix phone sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,6 +1030,7 @@ dependencies = [
  "ashpd 0.13.10",
  "async-stream",
  "ctrlc",
+ "dirs",
  "futures",
  "futures-util",
  "i18n-embed",

--- a/cosmic-ext-connect-applet/Cargo.toml
+++ b/cosmic-ext-connect-applet/Cargo.toml
@@ -29,6 +29,7 @@ notify-rust = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 zbus = { workspace = true }
+dirs = { workspace = true }
 i18n-embed = { version = "0.16", features = ["fluent-system", "desktop-requester"] }
 i18n-embed-fl = "0.10"
 rust-embed = "8"

--- a/cosmic-ext-connect-applet/src/backend.rs
+++ b/cosmic-ext-connect-applet/src/backend.rs
@@ -254,6 +254,15 @@ pub async fn execute_run_command(device_id: String, key: String) -> Result<()> {
     client.run_command(&device_id, &key).await
 }
 
+/// Notify the running service to re-send the local command list to a connected
+/// device. Call this immediately after adding or removing a local command so
+/// the phone reflects the change without waiting for reconnect.
+pub async fn push_local_commands(device_id: String) {
+    if let Some(client) = CLIENT.lock().await.clone() {
+        let _ = client.push_local_commands(&device_id).await;
+    }
+}
+
 /// Stream of service events. Reconnects automatically when the client is
 /// replaced (e.g. after session logout/login) or the stream ends.
 #[allow(dead_code)]

--- a/cosmic-ext-connect-applet/src/main.rs
+++ b/cosmic-ext-connect-applet/src/main.rs
@@ -450,12 +450,20 @@ fn main() -> cosmic::iced::Result {
 
     ctrlc::set_handler(move || std::process::exit(0)).ok();
 
-    // In a flatpak the host D-Bus daemon cannot activate /app/bin/kdeconnect-service
-    // because /app only exists inside the sandbox. Spawning here ensures the service
-    // is always running and places it in the same process group as the applet, so
-    // it is killed when the session ends. If the service is already running the new
-    // process exits immediately when the D-Bus name is already taken.
+    // Spawn the service in the same process group so it exits when the session ends.
+    // If the service is already running it exits immediately (D-Bus name already taken).
+    // Explicitly forward HOME so the service reads config from the correct path
+    // regardless of the environment the COSMIC panel provides.
+    let home = std::env::var("HOME").unwrap_or_else(|_| {
+        dirs::home_dir()
+            .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+            .to_string_lossy()
+            .to_string()
+    });
     let _ = std::process::Command::new("kdeconnect-service")
+        .env("HOME", &home)
+        .env("XDG_RUNTIME_DIR", std::env::var("XDG_RUNTIME_DIR").unwrap_or_default())
+        .env("XDG_CONFIG_HOME", std::env::var("XDG_CONFIG_HOME").unwrap_or_default())
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())

--- a/cosmic-ext-connect-applet/src/settings.rs
+++ b/cosmic-ext-connect-applet/src/settings.rs
@@ -11,28 +11,38 @@ use cosmic::{
 use cosmic_ext_connect_applet::{backend, models::Device};
 use futures::StreamExt as _;
 use std::collections::HashMap;
+use cosmic::cosmic_config::{ConfigGet, ConfigSet};
 
 /// A desktop command stored as JSON: {id, name, command}
 type LocalCommand = serde_json::Value;
 
-fn run_commands_path() -> std::path::PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    std::path::PathBuf::from(format!("{}/.config/kdeconnect/runcommand.json", home))
+const RUN_COMMANDS_CONFIG_ID: &str = "io.github.hepp3n.kdeconnect";
+const RUN_COMMANDS_CONFIG_VERSION: u64 = 1;
+const RUN_COMMANDS_CONFIG_KEY: &str = "run_commands";
+
+fn run_commands_config() -> Option<cosmic::cosmic_config::Config> {
+    cosmic::cosmic_config::Config::new(RUN_COMMANDS_CONFIG_ID, RUN_COMMANDS_CONFIG_VERSION).ok()
 }
 
 fn load_run_commands() -> Vec<LocalCommand> {
-    match std::fs::read_to_string(run_commands_path()) {
-        Ok(json) => serde_json::from_str::<Vec<LocalCommand>>(&json).unwrap_or_default(),
-        Err(_) => vec![],
-    }
+    run_commands_config()
+        .and_then(|cfg| cfg.get::<Vec<LocalCommand>>(RUN_COMMANDS_CONFIG_KEY).ok())
+        .unwrap_or_default()
 }
 
 fn save_run_commands(commands: &[LocalCommand]) {
-    let path = run_commands_path();
+    // Write to cosmic_config for applet persistence across sessions.
+    if let Some(cfg) = run_commands_config() {
+        let _ = cfg.set(RUN_COMMANDS_CONFIG_KEY, commands);
+    }
+    // Also write a plain JSON file for the service to read, since cosmic_config
+    // stores RON format which serde_json cannot parse.
+    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
+    let path = home.join(".config").join("kdeconnect").join("runcommand.json");
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    if let Ok(json) = serde_json::to_string_pretty(commands) {
+    if let Ok(json) = serde_json::to_string(commands) {
         let _ = std::fs::write(path, json);
     }
 }
@@ -441,11 +451,23 @@ impl Application for SettingsApp {
                     self.new_cmd_name.clear();
                     self.new_cmd_command.clear();
                     save_run_commands(&self.run_commands);
+                    if let Some(device_id) = self.selected_device.clone() {
+                        return Task::perform(
+                            async move { backend::push_local_commands(device_id).await },
+                            |_| Action::App(Message::Refresh),
+                        );
+                    }
                 }
             }
             Message::DeleteRunCommand(id) => {
                 self.run_commands.retain(|c| c["id"].as_str() != Some(&id));
                 save_run_commands(&self.run_commands);
+                if let Some(device_id) = self.selected_device.clone() {
+                    return Task::perform(
+                        async move { backend::push_local_commands(device_id).await },
+                        |_| Action::App(Message::Refresh),
+                    );
+                }
             }
         }
         Task::none()

--- a/cosmic-ext-connect-applet/src/settings.rs
+++ b/cosmic-ext-connect-applet/src/settings.rs
@@ -35,10 +35,16 @@ fn save_run_commands(commands: &[LocalCommand]) {
     if let Some(cfg) = run_commands_config() {
         let _ = cfg.set(RUN_COMMANDS_CONFIG_KEY, commands);
     }
-    // Also write a plain JSON file for the service to read, since cosmic_config
-    // stores RON format which serde_json cannot parse.
-    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
-    let path = home.join(".config").join("kdeconnect").join("runcommand.json");
+    let config_home = std::env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
+        dirs::home_dir()
+            .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+            .join(".config")
+            .to_string_lossy()
+            .to_string()
+    });
+    let path = std::path::PathBuf::from(config_home)
+        .join("kdeconnect")
+        .join("runcommand.json");
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }

--- a/io.github.hepp3n.kdeconnect.json
+++ b/io.github.hepp3n.kdeconnect.json
@@ -17,6 +17,8 @@
         "--share=network",
         "--filesystem=xdg-download",
         "--filesystem=xdg-config/cosmic:rw",
+        "--filesystem=xdg-config/kdeconnect:rw",
+        "--talk-name=org.freedesktop.Flatpak",
         "--socket=pulseaudio"
     ],
     "build-options": {

--- a/kdeconnect-core/src/event.rs
+++ b/kdeconnect-core/src/event.rs
@@ -29,6 +29,7 @@ pub enum CoreEvent {
         device: DeviceId,
         packet: ProtocolPacket,
     },
+
     SendPaylod {
         device: DeviceId,
         packet: ProtocolPacket,
@@ -51,6 +52,7 @@ pub enum AppEvent {
     MprisAction((DeviceId, String, MprisAction)),
     SendMprisRequest((DeviceId, MprisRequest)),
     SendPacket(DeviceId, ProtocolPacket),
+    PushLocalCommands(DeviceId),
     SetPluginEnabled {
         device_id: DeviceId,
         plugin_id: String,

--- a/kdeconnect-core/src/lib.rs
+++ b/kdeconnect-core/src/lib.rs
@@ -472,6 +472,9 @@ impl KdeConnectCore {
                     );
                 }
             }
+            AppEvent::PushLocalCommands(device_id) => {
+                plugins::run_command::send_command_list(&device_id, self.event_tx.clone()).await;
+            }
             AppEvent::SendFiles((device_id, files_list)) => {
                 info!("frontend trying to sent files to device: {}", device_id);
 

--- a/kdeconnect-core/src/plugins/run_command.rs
+++ b/kdeconnect-core/src/plugins/run_command.rs
@@ -18,26 +18,27 @@ pub struct LocalCommand {
     pub command: String,
 }
 
-/// Path to the global run-command config file.
-/// Stored as a JSON array of LocalCommand so the settings UI can read/write it.
-fn load_local_commands() -> Vec<LocalCommand> {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    let path = std::path::PathBuf::from(&home)
-        .join(".config")
+fn commands_config_path() -> std::path::PathBuf {
+    // Inside Flatpak XDG_CONFIG_HOME points to the sandboxed config dir.
+    // Outside Flatpak it is unset and falls back to ~/.config.
+    let config_home = std::env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+        format!("{}/.config", home)
+    });
+    std::path::PathBuf::from(config_home)
         .join("kdeconnect")
-        .join("runcommand.json");
-    match std::fs::read_to_string(&path) {
+        .join("runcommand.json")
+}
+
+fn load_local_commands() -> Vec<LocalCommand> {
+    match std::fs::read_to_string(commands_config_path()) {
         Ok(json_str) => serde_json::from_str::<Vec<LocalCommand>>(&json_str).unwrap_or_default(),
         Err(_) => vec![],
     }
 }
 
 fn save_local_commands(commands: &[LocalCommand]) {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    let path = std::path::PathBuf::from(&home)
-        .join(".config")
-        .join("kdeconnect")
-        .join("runcommand.json");
+    let path = commands_config_path();
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }

--- a/kdeconnect-core/src/plugins/run_command.rs
+++ b/kdeconnect-core/src/plugins/run_command.rs
@@ -20,18 +20,29 @@ pub struct LocalCommand {
 
 /// Path to the global run-command config file.
 /// Stored as a JSON array of LocalCommand so the settings UI can read/write it.
-fn commands_config_path() -> std::path::PathBuf {
-    dirs::config_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+fn load_local_commands() -> Vec<LocalCommand> {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    let path = std::path::PathBuf::from(&home)
+        .join(".config")
         .join("kdeconnect")
-        .join("runcommand.json")
+        .join("runcommand.json");
+    match std::fs::read_to_string(&path) {
+        Ok(json_str) => serde_json::from_str::<Vec<LocalCommand>>(&json_str).unwrap_or_default(),
+        Err(_) => vec![],
+    }
 }
 
-/// Load all locally defined commands (returns empty vec if file is missing).
-fn load_local_commands() -> Vec<LocalCommand> {
-    match std::fs::read_to_string(commands_config_path()) {
-        Ok(json) => serde_json::from_str(&json).unwrap_or_default(),
-        Err(_) => vec![],
+fn save_local_commands(commands: &[LocalCommand]) {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    let path = std::path::PathBuf::from(&home)
+        .join(".config")
+        .join("kdeconnect")
+        .join("runcommand.json");
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(json) = serde_json::to_string(&commands) {
+        let _ = std::fs::write(&path, json);
     }
 }
 
@@ -78,18 +89,56 @@ impl Plugin for RunCommandRequest {
 // ---------------------------------------------------------------------------
 
 impl RunCommand {
-    /// Desktop received a command list from the phone (bidirectional support).
-    /// Not the primary use case — log and ignore for now.
+    /// Phone sent us an updated command list — save any new commands to disk.
     pub async fn received_packet(
         &self,
         device: &crate::device::Device,
         _connection_tx: mpsc::UnboundedSender<crate::event::ConnectionEvent>,
-        _core_tx: mpsc::UnboundedSender<crate::event::CoreEvent>,
+        core_tx: mpsc::UnboundedSender<crate::event::CoreEvent>,
     ) {
-        info!(
-            "[runcommand] received command list from {} (canAddCommand={})",
-            device.device_id, self.can_add_command
-        );
+        // Parse the commandList JSON string into individual commands.
+        let incoming: std::collections::HashMap<String, serde_json::Value> =
+            match serde_json::from_str(&self.command_list) {
+                Ok(map) => map,
+                Err(e) => {
+                    warn!("[runcommand] failed to parse commandList from {}: {}", device.device_id, e);
+                    return;
+                }
+            };
+
+        if incoming.is_empty() {
+            return;
+        }
+
+        // Merge into existing commands — add any that aren't already present by id.
+        let mut commands = load_local_commands();
+        let mut changed = false;
+        for (key, val) in &incoming {
+            let name = val["name"].as_str().unwrap_or("").to_string();
+            let command = val["command"].as_str().unwrap_or("").to_string();
+            if name.is_empty() || command.is_empty() {
+                continue;
+            }
+            if !commands.iter().any(|c| c.id == *key) {
+                commands.push(LocalCommand {
+                    id: key.clone(),
+                    name,
+                    command,
+                });
+                changed = true;
+            }
+        }
+
+        if changed {
+            save_local_commands(&commands);
+            info!(
+                "[runcommand] saved {} new command(s) from {}",
+                incoming.len(),
+                device.device_id
+            );
+            // Re-send updated list back to phone to confirm.
+            send_command_list(&device.device_id, core_tx).await;
+        }
     }
 }
 
@@ -108,7 +157,9 @@ impl RunCommandRequest {
                     "[runcommand] executing '{}': {}",
                     cmd.name, cmd.command
                 );
-                if let Err(e) = std::process::Command::new("sh")
+                if let Err(e) = std::process::Command::new("flatpak-spawn")
+                    .arg("--host")
+                    .arg("sh")
                     .arg("-c")
                     .arg(&cmd.command)
                     .spawn()

--- a/kdeconnect-core/src/plugins/run_command.rs
+++ b/kdeconnect-core/src/plugins/run_command.rs
@@ -158,12 +158,20 @@ impl RunCommandRequest {
                     "[runcommand] executing '{}': {}",
                     cmd.name, cmd.command
                 );
-                if let Err(e) = std::process::Command::new("flatpak-spawn")
-                    .arg("--host")
-                    .arg("sh")
-                    .arg("-c")
-                    .arg(&cmd.command)
-                    .spawn()
+                let result = if std::env::var("FLATPAK_ID").is_ok() {
+                    std::process::Command::new("flatpak-spawn")
+                        .arg("--host")
+                        .arg("sh")
+                        .arg("-c")
+                        .arg(&cmd.command)
+                        .spawn()
+                } else {
+                    std::process::Command::new("sh")
+                        .arg("-c")
+                        .arg(&cmd.command)
+                        .spawn()
+                };
+                if let Err(e) = result
                 {
                     warn!("[runcommand] failed to spawn '{}': {}", cmd.name, e);
                 }

--- a/kdeconnect-dbus-client/src/lib.rs
+++ b/kdeconnect-dbus-client/src/lib.rs
@@ -66,6 +66,7 @@ trait Daemon {
     async fn reject_pairing(&self, device_id: &str) -> zbus::Result<()>;
     async fn run_command(&self, device_id: &str, key: &str) -> zbus::Result<()>;
     async fn request_run_commands(&self, device_id: &str) -> zbus::Result<()>;
+    async fn push_local_commands(&self, device_id: &str) -> zbus::Result<()>;
 
     #[zbus(signal)]
     async fn pairing_requested(&self, device_id: String, device_name: String) -> zbus::Result<()>;
@@ -239,6 +240,11 @@ impl KdeConnectClient {
     /// Request the remote command list from a device
     pub async fn request_run_commands(&self, device_id: &str) -> Result<()> {
         Ok(self.daemon_proxy.request_run_commands(device_id).await?)
+    }
+
+    /// Push our local command list to a connected device immediately.
+    pub async fn push_local_commands(&self, device_id: &str) -> Result<()> {
+        Ok(self.daemon_proxy.push_local_commands(device_id).await?)
     }
 
     /// Request SMS conversations

--- a/kdeconnect-service/src/dbus_interface.rs
+++ b/kdeconnect-service/src/dbus_interface.rs
@@ -346,6 +346,16 @@ impl DaemonInterface {
         Ok(())
     }
 
+    /// Push our local command list to a connected device immediately.
+    /// Call this after adding or removing a local command.
+    async fn push_local_commands(&self, device_id: String) -> zbus::fdo::Result<()> {
+        info!("D-Bus: PushLocalCommands called for {}", device_id);
+        self.event_sender
+            .send(AppEvent::PushLocalCommands(kdeconnect_core::device::DeviceId(device_id)))
+            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
+        Ok(())
+    }
+
     /// Signal: Remote command list received from a paired device.
     /// commands_json is a JSON array of {key, name, command} objects.
     #[zbus(signal)]


### PR DESCRIPTION
- Migrate command storage to XDG_CONFIG_HOME-aware sidecar JSON file
- Fix load_local_commands using hardcoded HOME instead of XDG_CONFIG_HOME
- Use flatpak-spawn --host for command execution inside Flatpak sandbox
- Add push_local_commands D-Bus method to sync changes to phone immediately
- Add ConfigGet/ConfigSet trait imports for cosmic_config