### PR TITLE
applet: add clipboard auto-sync polling

### DIFF
--- a/cosmic-ext-connect-applet/src/lib.rs
+++ b/cosmic-ext-connect-applet/src/lib.rs
@@ -35,6 +35,7 @@ pub mod backend;
 pub mod messages;
 pub mod models;
 pub mod notifications;
+pub mod plugin_config;
 pub mod plugins;
 pub mod portal;
 pub mod ui;

--- a/cosmic-ext-connect-applet/src/main.rs
+++ b/cosmic-ext-connect-applet/src/main.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate cosmic_ext_connect_applet;
 
-use cosmic_ext_connect_applet::{backend, messages, models, portal, ui};
+use cosmic_ext_connect_applet::{backend, messages, models, plugin_config, portal, ui};
 
 use messages::Message;
 use models::Device;
@@ -23,6 +23,8 @@ pub struct KdeConnectApplet {
     /// Pending pairing requests: device_id → device_name
     pairing_requests: HashMap<String, String>,
     accent_color: cosmic::iced::Color,
+    /// Last known clipboard content — used for change detection in auto-sync
+    last_clipboard: Option<String>,
 }
 
 impl cosmic::Application for KdeConnectApplet {
@@ -53,6 +55,7 @@ impl cosmic::Application for KdeConnectApplet {
             pairing_requests: HashMap::new(),
             accent_color: theme::try_load_cosmic_accent()
                 .unwrap_or(theme::FALLBACK_TEAL),
+            last_clipboard: None,
         };
 
         (app, Task::none())
@@ -234,6 +237,52 @@ impl cosmic::Application for KdeConnectApplet {
                     );
                 }
             }
+            Message::ClipboardPoll => {
+                return cosmic::iced::clipboard::read().map(|content| {
+                    cosmic::Action::App(Message::ClipboardMaybeSend(
+                        content.unwrap_or_default(),
+                    ))
+                });
+            }
+            Message::ClipboardMaybeSend(ref content) => {
+                if content.is_empty()
+                    || self.last_clipboard.as_deref() == Some(content)
+                {
+                    return Task::none();
+                }
+                self.last_clipboard = Some(content.clone());
+
+                let targets: Vec<String> = self
+                    .devices
+                    .iter()
+                    .filter(|(_, d)| d.is_paired && d.is_reachable)
+                    .map(|(id, _)| id.clone())
+                    .collect();
+
+                if targets.is_empty() {
+                    return Task::none();
+                }
+
+                let content = content.clone();
+                return Task::perform(
+                    async move {
+                        for device_id in targets {
+                            let cfg =
+                                plugin_config::ClipboardPluginConfig::load(&device_id)
+                                    .unwrap_or_default();
+                            if cfg.auto_share {
+                                let _ = backend::send_clipboard(
+                                    device_id,
+                                    content.clone(),
+                                )
+                                .await;
+                            }
+                        }
+                    },
+                    |_| cosmic::Action::App(Message::Noop),
+                );
+            }
+            Message::Noop => {}
             Message::ClipboardReceived(content) => {
                 return cosmic::iced::clipboard::write::<cosmic::Action<Message>>(content);
             }
@@ -408,6 +457,8 @@ impl cosmic::Application for KdeConnectApplet {
         Subscription::batch(vec![
             cosmic::iced::time::every(std::time::Duration::from_secs(10))
                 .map(|_| Message::RefreshDevices),
+            cosmic::iced::time::every(std::time::Duration::from_secs(1))
+                .map(|_| Message::ClipboardPoll),
             backend::filetransfer_subscription(),
             backend::service_watcher_subscription(),
             // D-Bus event stream — delivers pairing requests and device state

--- a/cosmic-ext-connect-applet/src/messages.rs
+++ b/cosmic-ext-connect-applet/src/messages.rs
@@ -27,6 +27,11 @@ pub enum Message {
     ClipboardReceived(String),
     // Desktop clipboard read result — content forwarded to device
     ClipboardReadForDevice(String, String), // device_id, content
+    // Periodic clipboard poll for auto-sync — reads desktop clipboard
+    ClipboardPoll,
+    // Clipboard content ready to check — send to devices if changed and auto_share enabled
+    ClipboardMaybeSend(String),
+    Noop,
 
     // Battery and connectivity updates — patch device in place without full refresh
     BatteryUpdated(String, i32, bool),  // device_id, level, is_charging


### PR DESCRIPTION
## Description

The ClipboardPluginConfig has an `auto_share` field that defaults to `true` and is correctly saved/loaded from `kdeconnect_clipboard/config`, but it's never read at runtime. There is no clipboard watcher in the codebase — desktop clipboard changes are never automatically sent to the phone. The user has to manually click "Share Clipboard" in the applet every time they copy something.

Additionally, phone-to-desktop clipboard sync (ClipboardReceived) doesn't work either. Diagnosis with dbus-monitor and phone-side logcat confirms the phone never sends the `kdeconnect.clipboard` packet, likely because the clipboard plugin isn't enabled for this device in the KDE Connect Android app's per-device plugin settings.

## Steps to reproduce

1. Pair a phone with the COSMIC KDE Connect extension
2. Copy some text on the laptop (Ctrl+C in any app)
3. Expected: clipboard appears on phone automatically
4. Actual: nothing happens until you manually click "Share Clipboard" in the applet

## Root cause

`cosmic-ext-connect-applet/src/main.rs` has no clipboard polling mechanism. The `ClipboardPluginConfig::auto_share` property is defined and persisted but never consumed by any runtime code.

## Proposed fix

Add a 1-second clipboard polling subscription that:
- Reads desktop clipboard via `cosmic::iced::clipboard::read()`
- Compares against last known content to detect changes
- Auto-sends to all paired+reachable devices whose per-device `auto_share` config is enabled

PR: https://github.com/AuthenticSm1les/kdeconnect/pull/1
