### PR TITLE
Fixed clipboard sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2841,6 +2841,8 @@ name = "kdeconnect-service"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "calloop",
+ "calloop-wayland-source",
  "dirs",
  "futures",
  "futures-util",
@@ -2852,6 +2854,8 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "wayland-client",
+ "wayland-protocols",
  "zbus",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ libcosmic = { git = "https://github.com/pop-os/libcosmic", default-features = fa
     "wgpu",
 ] }
 
-# [profile.release]
-# opt-level = 3
-# lto = true
-# codegen-units = 1
-# strip = true
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,10 @@ uuid = { version = "1.23.1", features = ["v4"] }
 zbus = "5.15"
 libpulse-binding = { version = "2.30" }
 tracing-appender = "0.2"
+calloop = "0.14.4"
+calloop-wayland-source = "0.4.1"
+wayland-client = "0.31.14"
+wayland-protocols = { version = "0.32.12", features = ["client", "staging"] }
 
 kdeconnect-core = { path = "kdeconnect-core" }
 kdeconnect-dbus-client = { path = "kdeconnect-dbus-client" }
@@ -53,8 +57,8 @@ libcosmic = { git = "https://github.com/pop-os/libcosmic", default-features = fa
     "wgpu",
 ] }
 
-[profile.release]
-opt-level = 3
-lto = true
-codegen-units = 1
-strip = true
+# [profile.release]
+# opt-level = 3
+# lto = true
+# codegen-units = 1
+# strip = true

--- a/cosmic-ext-connect-applet/i18n/cs/cosmic_ext_connect_applet.ftl
+++ b/cosmic-ext-connect-applet/i18n/cs/cosmic_ext_connect_applet.ftl
@@ -1,6 +1,7 @@
 # Applet header
 applet-title = Cosmic Ext Connect
 applet-settings = Nastavení
+applet-quit = Ukončit
 
 # Pairing
 pairing-requests = Žádosti o párování

--- a/cosmic-ext-connect-applet/i18n/en/cosmic_ext_connect_applet.ftl
+++ b/cosmic-ext-connect-applet/i18n/en/cosmic_ext_connect_applet.ftl
@@ -1,6 +1,7 @@
 # Applet header
 applet-title = Cosmic Ext Connect
 applet-settings = Settings
+applet-quit = Quit
 
 # Pairing
 pairing-requests = Pairing Requests

--- a/cosmic-ext-connect-applet/src/backend.rs
+++ b/cosmic-ext-connect-applet/src/backend.rs
@@ -25,12 +25,29 @@ pub async fn initialize() -> Result<()> {
     Ok(())
 }
 
+/// Return the shared D-Bus client, establishing it lazily when applet startup
+/// raced with the service acquiring its bus name.
+async fn client() -> Result<Arc<KdeConnectClient>> {
+    if let Some(client) = CLIENT.lock().await.clone() {
+        return Ok(client);
+    }
+
+    info!("D-Bus client is not ready; reconnecting");
+    let new_client = Arc::new(KdeConnectClient::new().await?);
+    let mut client_guard = CLIENT.lock().await;
+    Ok(client_guard
+        .get_or_insert_with(|| new_client.clone())
+        .clone())
+}
+
 /// Fetch all devices from the service
 pub async fn fetch_devices() -> Vec<Device> {
-    let client_guard = CLIENT.lock().await;
-    let Some(client) = client_guard.as_ref() else {
-        warn!("D-Bus client not initialized");
-        return vec![];
+    let client = match client().await {
+        Ok(client) => client,
+        Err(e) => {
+            warn!("D-Bus client not initialized: {:?}", e);
+            return vec![];
+        }
     };
 
     match client.list_devices().await {
@@ -65,7 +82,10 @@ pub async fn fetch_devices() -> Vec<Device> {
                         has_presenter: false,
                         has_lockdevice: false,
                         has_virtualmonitor: false,
-                        run_commands: existing.as_ref().map(|e| e.run_commands.clone()).unwrap_or_default(),
+                        run_commands: existing
+                            .as_ref()
+                            .map(|e| e.run_commands.clone())
+                            .unwrap_or_default(),
                     };
                     cache.insert(d.id.clone(), device.clone());
                     device
@@ -127,13 +147,17 @@ pub async fn send_files(device_id: String, files: Vec<String>) -> Result<()> {
     client.send_files(&device_id, files).await
 }
 
-/// Send clipboard content to a device
-pub async fn send_clipboard(device_id: String, content: String) -> Result<()> {
-    let client_guard = CLIENT.lock().await;
-    let Some(client) = client_guard.as_ref() else {
-        return Err(anyhow::anyhow!("D-Bus client not initialized"));
-    };
-    client.send_clipboard(&device_id, &content).await
+/// Ask the service to read its background clipboard cache and send it.
+pub async fn share_clipboard(device_id: String) -> Result<()> {
+    let client = client().await?;
+    client.share_clipboard(&device_id).await
+}
+
+/// Stop the background service. Used by the applet's explicit Quit action so
+/// a subsequent debug run cannot reconnect to a stale daemon binary.
+pub async fn quit_service() -> Result<()> {
+    let client = client().await?;
+    client.quit().await
 }
 
 /// Browse device filesystem (via SFTP)
@@ -176,7 +200,9 @@ pub async fn set_plugin_enabled(device_id: String, plugin_id: String, enabled: b
     let Some(client) = client_guard.as_ref() else {
         return Err(anyhow::anyhow!("D-Bus client not initialized"));
     };
-    client.set_plugin_enabled(&device_id, &plugin_id, enabled).await
+    client
+        .set_plugin_enabled(&device_id, &plugin_id, enabled)
+        .await
 }
 
 /// Return the list of disabled plugin IDs for a device

--- a/cosmic-ext-connect-applet/src/cosmic-ext-connect-sms.rs
+++ b/cosmic-ext-connect-applet/src/cosmic-ext-connect-sms.rs
@@ -23,7 +23,10 @@ fn main() -> cosmic::iced::Result {
         .cloned()
         .unwrap_or_else(|| "Unknown Device".to_string());
 
-    info!("KDE Connect SMS window starting: {} ({})", device_name, device_id);
+    info!(
+        "KDE Connect SMS window starting: {} ({})",
+        device_name, device_id
+    );
 
     cosmic_ext_connect_applet::plugins::sms::run(device_id, device_name)
 }

--- a/cosmic-ext-connect-applet/src/lib.rs
+++ b/cosmic-ext-connect-applet/src/lib.rs
@@ -35,6 +35,7 @@ pub mod backend;
 pub mod messages;
 pub mod models;
 pub mod notifications;
+pub mod plugin_config;
 pub mod plugins;
 pub mod portal;
 pub mod ui;

--- a/cosmic-ext-connect-applet/src/lib.rs
+++ b/cosmic-ext-connect-applet/src/lib.rs
@@ -4,8 +4,8 @@
 //! settings window, and SMS window binaries.
 
 use i18n_embed::{
-    fluent::{fluent_language_loader, FluentLanguageLoader},
     DesktopLanguageRequester,
+    fluent::{FluentLanguageLoader, fluent_language_loader},
 };
 use rust_embed::RustEmbed;
 
@@ -38,8 +38,8 @@ pub mod notifications;
 pub mod plugin_config;
 pub mod plugins;
 pub mod portal;
-pub mod ui;
 pub mod theme;
+pub mod ui;
 
 // Re-export commonly used types
 pub use notifications::{PairingNotification, start_notification_listener};

--- a/cosmic-ext-connect-applet/src/main.rs
+++ b/cosmic-ext-connect-applet/src/main.rs
@@ -7,13 +7,14 @@ use messages::Message;
 use models::Device;
 
 use cosmic::app::Core;
+use cosmic::iced::platform_specific::shell::commands::popup::{destroy_popup, get_popup};
 use cosmic::iced::window::Id as SurfaceId;
 use cosmic::iced::{Limits, Subscription};
-use cosmic::iced::platform_specific::shell::commands::popup::{destroy_popup, get_popup};
+use cosmic::widget::menu;
 use cosmic::{Element, Task, widget};
-use std::collections::HashMap;
 use cosmic_ext_connect_applet::theme;
-use tracing::{debug, error, info};
+use std::collections::HashMap;
+use tracing::{debug, error, info, warn};
 
 pub struct KdeConnectApplet {
     core: Core,
@@ -23,6 +24,21 @@ pub struct KdeConnectApplet {
     /// Pending pairing requests: device_id → device_name
     pairing_requests: HashMap<String, String>,
     accent_color: cosmic::iced::Color,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AppletMenuAction {
+    Quit,
+}
+
+impl menu::Action for AppletMenuAction {
+    type Message = Message;
+
+    fn message(&self) -> Self::Message {
+        match self {
+            Self::Quit => Message::Quit,
+        }
+    }
 }
 
 impl cosmic::Application for KdeConnectApplet {
@@ -51,8 +67,7 @@ impl cosmic::Application for KdeConnectApplet {
             devices: HashMap::new(),
             expanded_device: None,
             pairing_requests: HashMap::new(),
-            accent_color: theme::try_load_cosmic_accent()
-                .unwrap_or(theme::FALLBACK_TEAL),
+            accent_color: theme::try_load_cosmic_accent().unwrap_or(theme::FALLBACK_TEAL),
         };
 
         (app, Task::none())
@@ -65,8 +80,7 @@ impl cosmic::Application for KdeConnectApplet {
     fn update(&mut self, message: Self::Message) -> Task<cosmic::Action<Self::Message>> {
         match message {
             Message::TogglePopup => {
-                self.accent_color = theme::try_load_cosmic_accent()
-                    .unwrap_or(theme::FALLBACK_TEAL);
+                self.accent_color = theme::try_load_cosmic_accent().unwrap_or(theme::FALLBACK_TEAL);
                 return if let Some(p) = self.popup.take() {
                     destroy_popup(p)
                 } else {
@@ -99,6 +113,23 @@ impl cosmic::Application for KdeConnectApplet {
                     self.popup = None;
                 }
             }
+            Message::Surface(action) => {
+                return cosmic::task::message(cosmic::Action::Cosmic(
+                    cosmic::app::Action::Surface(action),
+                ));
+            }
+            Message::Quit => {
+                return Task::perform(
+                    async { backend::quit_service().await.map_err(|e| e.to_string()) },
+                    |result| cosmic::Action::App(Message::QuitFinished(result)),
+                );
+            }
+            Message::QuitFinished(result) => {
+                if let Err(e) = result {
+                    warn!("Failed to stop kdeconnect-service cleanly: {}", e);
+                }
+                std::process::exit(0);
+            }
             Message::RefreshDevices => {
                 return Task::perform(backend::fetch_devices(), |devices| {
                     cosmic::Action::App(Message::DevicesUpdated(devices))
@@ -122,7 +153,9 @@ impl cosmic::Application for KdeConnectApplet {
                     self.expanded_device = Some(device_id.clone());
                     let id = device_id.clone();
                     return Task::perform(
-                        async move { backend::request_run_commands(id).await.ok(); },
+                        async move {
+                            backend::request_run_commands(id).await.ok();
+                        },
                         |_| cosmic::Action::App(Message::RefreshDevices),
                     );
                 }
@@ -219,38 +252,43 @@ impl cosmic::Application for KdeConnectApplet {
             }
             Message::ShareClipboard(ref device_id) => {
                 let id = device_id.clone();
-                return cosmic::iced::clipboard::read().map(move |content| {
-                    cosmic::Action::App(Message::ClipboardReadForDevice(
-                        id.clone(),
-                        content.unwrap_or_default(),
-                    ))
-                });
+                let result_device_id = id.clone();
+                return Task::perform(
+                    async move {
+                        backend::share_clipboard(id)
+                            .await
+                            .map_err(|e| e.to_string())
+                    },
+                    move |result| {
+                        cosmic::Action::App(Message::ClipboardSendFinished {
+                            device_id: result_device_id.clone(),
+                            result,
+                        })
+                    },
+                );
             }
-            Message::ClipboardReadForDevice(device_id, content) => {
-                if !content.is_empty() {
-                    return Task::perform(
-                        async move { backend::send_clipboard(device_id, content).await.ok(); },
-                        |_| cosmic::Action::App(Message::RefreshDevices),
-                    );
-                }
-            }
-            Message::ClipboardReceived(content) => {
-                return cosmic::iced::clipboard::write::<cosmic::Action<Message>>(content);
-            }
+            Message::ClipboardSendFinished { device_id, result } => match result {
+                Ok(()) => debug!("Manual clipboard sent to {}", device_id),
+                Err(e) => warn!("Manual clipboard send to {} failed: {}", device_id, e),
+            },
             Message::BatteryUpdated(device_id, level, charging) => {
                 if let Some(device) = self.devices.get_mut(&device_id) {
                     device.battery_level = Some(level);
                     device.is_charging = Some(charging);
                     // Also patch the backend cache so the next fetch_devices() preserves it
                     let d = device.clone();
-                    tokio::spawn(async move { backend::update_device(device_id, d).await; });
+                    tokio::spawn(async move {
+                        backend::update_device(device_id, d).await;
+                    });
                 }
             }
             Message::ConnectivityUpdated(device_id, strength) => {
                 if let Some(device) = self.devices.get_mut(&device_id) {
                     device.signal_strength = Some(strength);
                     let d = device.clone();
-                    tokio::spawn(async move { backend::update_device(device_id, d).await; });
+                    tokio::spawn(async move {
+                        backend::update_device(device_id, d).await;
+                    });
                 }
             }
             Message::AcceptPairing(ref device_id) => {
@@ -274,7 +312,10 @@ impl cosmic::Application for KdeConnectApplet {
                 );
             }
             Message::PairingRequestReceived(device_id, device_name, _device_type) => {
-                info!("Pairing request received from {} ({})", device_name, device_id);
+                info!(
+                    "Pairing request received from {} ({})",
+                    device_name, device_id
+                );
                 self.pairing_requests.insert(device_id, device_name.clone());
 
                 // Show a system notification so the user is alerted even if they
@@ -341,7 +382,9 @@ impl cosmic::Application for KdeConnectApplet {
             Message::RequestRunCommands(ref device_id) => {
                 let id = device_id.clone();
                 return Task::perform(
-                    async move { backend::request_run_commands(id).await.ok(); },
+                    async move {
+                        backend::request_run_commands(id).await.ok();
+                    },
                     |_| cosmic::Action::App(Message::RefreshDevices),
                 );
             }
@@ -360,14 +403,18 @@ impl cosmic::Application for KdeConnectApplet {
                     device.run_commands = commands;
                     let d = device.clone();
                     let did = device_id.clone();
-                    tokio::spawn(async move { backend::update_device(did, d).await; });
+                    tokio::spawn(async move {
+                        backend::update_device(did, d).await;
+                    });
                 }
             }
             Message::ExecuteRunCommand(ref device_id, ref key) => {
                 let id = device_id.clone();
                 let k = key.clone();
                 return Task::perform(
-                    async move { backend::execute_run_command(id, k).await.ok(); },
+                    async move {
+                        backend::execute_run_command(id, k).await.ok();
+                    },
                     |_| cosmic::Action::App(Message::RefreshDevices),
                 );
             }
@@ -376,11 +423,25 @@ impl cosmic::Application for KdeConnectApplet {
     }
 
     fn view(&self) -> Element<'_, Self::Message> {
-        self.core
+        let icon_button = self
+            .core
             .applet
             .icon_button("phone-symbolic")
-            .on_press(Message::TogglePopup)
-            .into()
+            .on_press(Message::TogglePopup);
+
+        widget::context_menu(
+            icon_button,
+            Some(menu::items(
+                &HashMap::new(),
+                vec![menu::Item::Button(
+                    fl!("applet-quit"),
+                    None,
+                    AppletMenuAction::Quit,
+                )],
+            )),
+        )
+        .on_surface_action(Message::Surface)
+        .into()
     }
 
     fn view_window(&self, id: SurfaceId) -> Element<'_, Self::Message> {
@@ -405,7 +466,7 @@ impl cosmic::Application for KdeConnectApplet {
 
     fn subscription(&self) -> Subscription<Self::Message> {
         use futures::StreamExt as _;
-        Subscription::batch(vec![
+        let subscriptions = vec![
             cosmic::iced::time::every(std::time::Duration::from_secs(10))
                 .map(|_| Message::RefreshDevices),
             backend::filetransfer_subscription(),
@@ -420,9 +481,7 @@ impl cosmic::Application for KdeConnectApplet {
                             kdeconnect_dbus_client::ServiceEvent::PairingRequested(id, name) => {
                                 yield Message::PairingRequestReceived(id, name, "phone".to_string());
                             }
-                            kdeconnect_dbus_client::ServiceEvent::ClipboardReceived(content) => {
-                                yield Message::ClipboardReceived(content);
-                            }
+                            kdeconnect_dbus_client::ServiceEvent::ClipboardReceived(_) => {}
                             kdeconnect_dbus_client::ServiceEvent::BatteryReceived(id, level, charging) => {
                                 yield Message::BatteryUpdated(id, level, charging);
                             }
@@ -443,7 +502,9 @@ impl cosmic::Application for KdeConnectApplet {
                     }
                 }
             }),
-        ])
+        ];
+
+        Subscription::batch(subscriptions)
     }
 }
 
@@ -458,8 +519,7 @@ fn main() -> cosmic::iced::Result {
     if std::env::var("KDECONNECT_LOG_FILE").is_ok_and(|v| !v.is_empty())
         && std::path::Path::new("/.flatpak-info").exists()
     {
-        let log_dir = dirs::data_dir()
-            .unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
+        let log_dir = dirs::data_dir().unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
         let _ = std::fs::create_dir_all(&log_dir);
         let file = std::fs::OpenOptions::new()
             .create(true)
@@ -497,8 +557,14 @@ fn main() -> cosmic::iced::Result {
     });
     let _ = std::process::Command::new("kdeconnect-service")
         .env("HOME", &home)
-        .env("XDG_RUNTIME_DIR", std::env::var("XDG_RUNTIME_DIR").unwrap_or_default())
-        .env("XDG_CONFIG_HOME", std::env::var("XDG_CONFIG_HOME").unwrap_or_default())
+        .env(
+            "XDG_RUNTIME_DIR",
+            std::env::var("XDG_RUNTIME_DIR").unwrap_or_default(),
+        )
+        .env(
+            "XDG_CONFIG_HOME",
+            std::env::var("XDG_CONFIG_HOME").unwrap_or_default(),
+        )
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())

--- a/cosmic-ext-connect-applet/src/messages.rs
+++ b/cosmic-ext-connect-applet/src/messages.rs
@@ -6,6 +6,9 @@ use crate::models::Device;
 pub enum Message {
     TogglePopup,
     PopupClosed(cosmic::iced::window::Id),
+    Surface(cosmic::surface::Action),
+    Quit,
+    QuitFinished(Result<(), String>),
     RefreshDevices,
     DevicesUpdated(Vec<Device>),
     ToggleDeviceMenu(String),
@@ -23,14 +26,14 @@ pub enum Message {
     ShareUrl(String),
     UpdateTransferProgress(u8),
 
-    // Clipboard received from phone — written to the desktop clipboard
-    ClipboardReceived(String),
-    // Desktop clipboard read result — content forwarded to device
-    ClipboardReadForDevice(String, String), // device_id, content
+    ClipboardSendFinished {
+        device_id: String,
+        result: Result<(), String>,
+    },
 
     // Battery and connectivity updates — patch device in place without full refresh
-    BatteryUpdated(String, i32, bool),  // device_id, level, is_charging
-    ConnectivityUpdated(String, i32),   // device_id, signal_strength
+    BatteryUpdated(String, i32, bool), // device_id, level, is_charging
+    ConnectivityUpdated(String, i32),  // device_id, signal_strength
 
     // Advanced features
     RemoteInput(String),
@@ -51,7 +54,7 @@ pub enum Message {
     MprisReceived(String, serde_json::Value), // device_id, mpris_data
 
     // Run Command
-    RequestRunCommands(String),              // device_id
-    RunCommandsReceived(String, String),     // device_id, commands_json
-    ExecuteRunCommand(String, String),       // device_id, key
+    RequestRunCommands(String),          // device_id
+    RunCommandsReceived(String, String), // device_id, commands_json
+    ExecuteRunCommand(String, String),   // device_id, key
 }

--- a/cosmic-ext-connect-applet/src/plugin_config.rs
+++ b/cosmic-ext-connect-applet/src/plugin_config.rs
@@ -120,7 +120,6 @@ impl ClipboardPluginConfig {
         let config_path = Self::get_config_path(device_id);
         
         if !config_path.exists() {
-            eprintln!("Clipboard plugin config not found for device {}, using defaults", device_id);
             return Ok(Self::default());
         }
         
@@ -179,8 +178,12 @@ impl ClipboardPluginConfig {
     
     /// Get the config file path for a device's clipboard plugin
     fn get_config_path(device_id: &str) -> PathBuf {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-        PathBuf::from(format!("{}/.config/kdeconnect/{}/kdeconnect_clipboard/config", home, device_id))
+        dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("/tmp"))
+            .join("kdeconnect")
+            .join(device_id)
+            .join("kdeconnect_clipboard")
+            .join("config")
     }
     
     /// Check if a config file exists for the device

--- a/cosmic-ext-connect-applet/src/plugin_config.rs
+++ b/cosmic-ext-connect-applet/src/plugin_config.rs
@@ -3,9 +3,9 @@
 //! This module handles reading and writing plugin-specific configuration
 //! settings for each device, stored in ~/.config/kdeconnect/{device_id}/{plugin_name}/config
 
-use std::path::PathBuf;
 use std::fs;
 use std::io::{self, Write};
+use std::path::PathBuf;
 
 /// Configuration for the Share plugin (file transfer)
 #[derive(Debug, Clone)]
@@ -19,7 +19,7 @@ impl Default for SharePluginConfig {
         // Default to Downloads folder
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
         let default_path = format!("{}/Downloads", home);
-        
+
         Self {
             destination_path: default_path,
         }
@@ -30,27 +30,30 @@ impl SharePluginConfig {
     /// Load configuration from file
     pub fn load(device_id: &str) -> io::Result<Self> {
         let config_path = Self::get_config_path(device_id);
-        
+
         if !config_path.exists() {
-            eprintln!("Share plugin config not found for device {}, using defaults", device_id);
+            eprintln!(
+                "Share plugin config not found for device {}, using defaults",
+                device_id
+            );
             return Ok(Self::default());
         }
-        
+
         let content = fs::read_to_string(&config_path)?;
-        
+
         // Parse the KDE config file format (key=value)
         let mut config = Self::default();
-        
+
         for line in content.lines() {
             let line = line.trim();
             if line.is_empty() || line.starts_with('#') || line.starts_with('[') {
                 continue;
             }
-            
+
             if let Some((key, value)) = line.split_once('=') {
                 let key = key.trim();
                 let value = value.trim();
-                
+
                 match key {
                     "incomingPath" | "destinationPath" => {
                         config.destination_path = value.to_string();
@@ -59,37 +62,40 @@ impl SharePluginConfig {
                 }
             }
         }
-        
+
         Ok(config)
     }
-    
+
     /// Save configuration to file
     pub fn save(&self, device_id: &str) -> io::Result<()> {
         let config_path = Self::get_config_path(device_id);
-        
+
         // Ensure directory exists
         if let Some(parent) = config_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        
+
         // Write config file in KDE config format
         let mut file = fs::File::create(&config_path)?;
         writeln!(file, "[General]")?;
         writeln!(file, "incomingPath={}", self.destination_path)?;
-        
+
         eprintln!("✓ Saved share plugin config for device {}", device_id);
         eprintln!("  Path: {}", config_path.display());
         eprintln!("  Destination: {}", self.destination_path);
-        
+
         Ok(())
     }
-    
+
     /// Get the config file path for a device's share plugin
     fn get_config_path(device_id: &str) -> PathBuf {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-        PathBuf::from(format!("{}/.config/kdeconnect/{}/kdeconnect_share/config", home, device_id))
+        PathBuf::from(format!(
+            "{}/.config/kdeconnect/{}/kdeconnect_share/config",
+            home, device_id
+        ))
     }
-    
+
     /// Check if a config file exists for the device
     pub fn exists(device_id: &str) -> bool {
         Self::get_config_path(device_id).exists()
@@ -108,8 +114,8 @@ pub struct ClipboardPluginConfig {
 impl Default for ClipboardPluginConfig {
     fn default() -> Self {
         Self {
-            auto_share: true,      // Auto-sync enabled by default
-            send_password: false,  // Don't share passwords by default (security)
+            auto_share: true,     // Auto-sync enabled by default
+            send_password: false, // Don't share passwords by default (security)
         }
     }
 }
@@ -118,26 +124,26 @@ impl ClipboardPluginConfig {
     /// Load configuration from file
     pub fn load(device_id: &str) -> io::Result<Self> {
         let config_path = Self::get_config_path(device_id);
-        
+
         if !config_path.exists() {
             return Ok(Self::default());
         }
-        
+
         let content = fs::read_to_string(&config_path)?;
-        
+
         // Parse the KDE config file format (key=value)
         let mut config = Self::default();
-        
+
         for line in content.lines() {
             let line = line.trim();
             if line.is_empty() || line.starts_with('#') || line.starts_with('[') {
                 continue;
             }
-            
+
             if let Some((key, value)) = line.split_once('=') {
                 let key = key.trim();
                 let value = value.trim();
-                
+
                 match key {
                     "autoShare" => {
                         config.auto_share = value.parse::<bool>().unwrap_or(true);
@@ -149,33 +155,33 @@ impl ClipboardPluginConfig {
                 }
             }
         }
-        
+
         Ok(config)
     }
-    
+
     /// Save configuration to file
     pub fn save(&self, device_id: &str) -> io::Result<()> {
         let config_path = Self::get_config_path(device_id);
-        
+
         // Ensure directory exists
         if let Some(parent) = config_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        
+
         // Write config file in KDE config format
         let mut file = fs::File::create(&config_path)?;
         writeln!(file, "[General]")?;
         writeln!(file, "autoShare={}", self.auto_share)?;
         writeln!(file, "sendPassword={}", self.send_password)?;
-        
+
         eprintln!("✓ Saved clipboard plugin config for device {}", device_id);
         eprintln!("  Path: {}", config_path.display());
         eprintln!("  Auto share: {}", self.auto_share);
         eprintln!("  Send passwords: {}", self.send_password);
-        
+
         Ok(())
     }
-    
+
     /// Get the config file path for a device's clipboard plugin
     fn get_config_path(device_id: &str) -> PathBuf {
         dirs::config_dir()
@@ -185,7 +191,7 @@ impl ClipboardPluginConfig {
             .join("kdeconnect_clipboard")
             .join("config")
     }
-    
+
     /// Check if a config file exists for the device
     pub fn exists(device_id: &str) -> bool {
         Self::get_config_path(device_id).exists()
@@ -229,48 +235,53 @@ impl RunCommandPluginConfig {
     /// Load configuration from file
     pub fn load(device_id: &str) -> io::Result<Self> {
         let config_path = Self::get_config_path(device_id);
-        
+
         if !config_path.exists() {
-            eprintln!("RunCommand plugin config not found for device {}, using defaults", device_id);
+            eprintln!(
+                "RunCommand plugin config not found for device {}, using defaults",
+                device_id
+            );
             return Ok(Self::default());
         }
-        
+
         let content = fs::read_to_string(&config_path)?;
-        
+
         // Parse the KDE config file format
         let mut commands = Vec::new();
         let mut current_group: Option<String> = None;
         let mut current_name: Option<String> = None;
         let mut current_command: Option<String> = None;
-        
+
         for line in content.lines() {
             let line = line.trim();
             if line.is_empty() || line.starts_with('#') {
                 continue;
             }
-            
+
             // Group header like [command_0]
             if line.starts_with('[') && line.ends_with(']') {
                 // Save previous command if complete
-                if let (Some(id), Some(name), Some(cmd)) = (&current_group, &current_name, &current_command) {
+                if let (Some(id), Some(name), Some(cmd)) =
+                    (&current_group, &current_name, &current_command)
+                {
                     commands.push(RemoteCommand {
                         id: id.clone(),
                         name: name.clone(),
                         command: cmd.clone(),
                     });
                 }
-                
+
                 // Start new command group
-                current_group = Some(line[1..line.len()-1].to_string());
+                current_group = Some(line[1..line.len() - 1].to_string());
                 current_name = None;
                 current_command = None;
                 continue;
             }
-            
+
             if let Some((key, value)) = line.split_once('=') {
                 let key = key.trim();
                 let value = value.trim();
-                
+
                 match key {
                     "name" => {
                         current_name = Some(value.to_string());
@@ -282,7 +293,7 @@ impl RunCommandPluginConfig {
                 }
             }
         }
-        
+
         // Save last command if complete
         if let (Some(id), Some(name), Some(cmd)) = (current_group, current_name, current_command) {
             commands.push(RemoteCommand {
@@ -291,22 +302,22 @@ impl RunCommandPluginConfig {
                 command: cmd,
             });
         }
-        
+
         Ok(Self { commands })
     }
-    
+
     /// Save configuration to file
     pub fn save(&self, device_id: &str) -> io::Result<()> {
         let config_path = Self::get_config_path(device_id);
-        
+
         // Ensure directory exists
         if let Some(parent) = config_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        
+
         // Write config file in KDE config format
         let mut file = fs::File::create(&config_path)?;
-        
+
         // Write each command as a group
         for (index, cmd) in self.commands.iter().enumerate() {
             writeln!(file, "[command_{}]", index)?;
@@ -314,20 +325,23 @@ impl RunCommandPluginConfig {
             writeln!(file, "command={}", cmd.command)?;
             writeln!(file)?; // Empty line between groups
         }
-        
+
         eprintln!("✓ Saved runcommand plugin config for device {}", device_id);
         eprintln!("  Path: {}", config_path.display());
         eprintln!("  Commands: {}", self.commands.len());
-        
+
         Ok(())
     }
-    
+
     /// Get the config file path for a device's runcommand plugin
     fn get_config_path(device_id: &str) -> PathBuf {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-        PathBuf::from(format!("{}/.config/kdeconnect/{}/kdeconnect_runcommand/config", home, device_id))
+        PathBuf::from(format!(
+            "{}/.config/kdeconnect/{}/kdeconnect_runcommand/config",
+            home, device_id
+        ))
     }
-    
+
     /// Check if a config file exists for the device
     pub fn exists(device_id: &str) -> bool {
         Self::get_config_path(device_id).exists()
@@ -338,15 +352,15 @@ impl RunCommandPluginConfig {
 #[derive(Debug, Clone)]
 pub struct PauseMusicPluginConfig {
     /// When to pause media
-    pub pause_on_ringing: bool,      // Pause as soon as phone rings
+    pub pause_on_ringing: bool, // Pause as soon as phone rings
     pub pause_only_on_talking: bool, // Pause only while talking
-    
+
     /// What to pause/mute
-    pub pause_media: bool,            // Pause media players
-    pub mute_system_sound: bool,      // Mute system sound
-    
+    pub pause_media: bool, // Pause media players
+    pub mute_system_sound: bool, // Mute system sound
+
     /// Auto-resume
-    pub resume_after_call: bool,      // Automatically resume media when call finished
+    pub resume_after_call: bool, // Automatically resume media when call finished
 }
 
 impl Default for PauseMusicPluginConfig {
@@ -355,11 +369,11 @@ impl Default for PauseMusicPluginConfig {
             // Conditions - pause as soon as phone rings by default
             pause_on_ringing: true,
             pause_only_on_talking: false,
-            
+
             // Actions - pause media by default, don't mute system
             pause_media: true,
             mute_system_sound: false,
-            
+
             // Auto-resume enabled by default
             resume_after_call: true,
         }
@@ -370,27 +384,30 @@ impl PauseMusicPluginConfig {
     /// Load configuration from file
     pub fn load(device_id: &str) -> io::Result<Self> {
         let config_path = Self::get_config_path(device_id);
-        
+
         if !config_path.exists() {
-            eprintln!("PauseMusic plugin config not found for device {}, using defaults", device_id);
+            eprintln!(
+                "PauseMusic plugin config not found for device {}, using defaults",
+                device_id
+            );
             return Ok(Self::default());
         }
-        
+
         let content = fs::read_to_string(&config_path)?;
-        
+
         // Parse the KDE config file format (key=value)
         let mut config = Self::default();
-        
+
         for line in content.lines() {
             let line = line.trim();
             if line.is_empty() || line.starts_with('#') || line.starts_with('[') {
                 continue;
             }
-            
+
             if let Some((key, value)) = line.split_once('=') {
                 let key = key.trim();
                 let value = value.trim();
-                
+
                 match key {
                     "pause_on_ringing" | "pauseOnRinging" => {
                         config.pause_on_ringing = value.parse::<bool>().unwrap_or(true);
@@ -411,19 +428,19 @@ impl PauseMusicPluginConfig {
                 }
             }
         }
-        
+
         Ok(config)
     }
-    
+
     /// Save configuration to file
     pub fn save(&self, device_id: &str) -> io::Result<()> {
         let config_path = Self::get_config_path(device_id);
-        
+
         // Ensure directory exists
         if let Some(parent) = config_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        
+
         // Write config file in KDE config format
         let mut file = fs::File::create(&config_path)?;
         writeln!(file, "[General]")?;
@@ -432,7 +449,7 @@ impl PauseMusicPluginConfig {
         writeln!(file, "pauseMedia={}", self.pause_media)?;
         writeln!(file, "muteSystemSound={}", self.mute_system_sound)?;
         writeln!(file, "resumeAfterCall={}", self.resume_after_call)?;
-        
+
         eprintln!("✓ Saved pausemusic plugin config for device {}", device_id);
         eprintln!("  Path: {}", config_path.display());
         eprintln!("  Pause on ringing: {}", self.pause_on_ringing);
@@ -440,16 +457,19 @@ impl PauseMusicPluginConfig {
         eprintln!("  Pause media: {}", self.pause_media);
         eprintln!("  Mute system: {}", self.mute_system_sound);
         eprintln!("  Resume after call: {}", self.resume_after_call);
-        
+
         Ok(())
     }
-    
+
     /// Get the config file path for a device's pausemusic plugin
     fn get_config_path(device_id: &str) -> PathBuf {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-        PathBuf::from(format!("{}/.config/kdeconnect/{}/kdeconnect_pausemusic/config", home, device_id))
+        PathBuf::from(format!(
+            "{}/.config/kdeconnect/{}/kdeconnect_pausemusic/config",
+            home, device_id
+        ))
     }
-    
+
     /// Check if a config file exists for the device
     pub fn exists(device_id: &str) -> bool {
         Self::get_config_path(device_id).exists()
@@ -466,17 +486,25 @@ pub struct FindMyPhonePluginConfig {
 impl Default for FindMyPhonePluginConfig {
     fn default() -> Self {
         // Default to system bell sound or a common ringtone path
-        let default_sound = if std::path::Path::new("/usr/share/sounds/freedesktop/stereo/phone-incoming-call.oga").exists() {
-            "/usr/share/sounds/freedesktop/stereo/phone-incoming-call.oga".to_string()
-        } else if std::path::Path::new("/usr/share/sounds/freedesktop/stereo/bell.oga").exists() {
-            "/usr/share/sounds/freedesktop/stereo/bell.oga".to_string()
-        } else if std::path::Path::new("/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga").exists() {
-            "/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga".to_string()
-        } else {
-            // Fallback to empty string, plugin will use system default
-            String::new()
-        };
-        
+        let default_sound =
+            if std::path::Path::new("/usr/share/sounds/freedesktop/stereo/phone-incoming-call.oga")
+                .exists()
+            {
+                "/usr/share/sounds/freedesktop/stereo/phone-incoming-call.oga".to_string()
+            } else if std::path::Path::new("/usr/share/sounds/freedesktop/stereo/bell.oga").exists()
+            {
+                "/usr/share/sounds/freedesktop/stereo/bell.oga".to_string()
+            } else if std::path::Path::new(
+                "/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga",
+            )
+            .exists()
+            {
+                "/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga".to_string()
+            } else {
+                // Fallback to empty string, plugin will use system default
+                String::new()
+            };
+
         Self {
             ringtone_path: default_sound,
         }
@@ -487,27 +515,30 @@ impl FindMyPhonePluginConfig {
     /// Load configuration from file
     pub fn load(device_id: &str) -> io::Result<Self> {
         let config_path = Self::get_config_path(device_id);
-        
+
         if !config_path.exists() {
-            eprintln!("FindMyPhone plugin config not found for device {}, using defaults", device_id);
+            eprintln!(
+                "FindMyPhone plugin config not found for device {}, using defaults",
+                device_id
+            );
             return Ok(Self::default());
         }
-        
+
         let content = fs::read_to_string(&config_path)?;
-        
+
         // Parse the KDE config file format (key=value)
         let mut config = Self::default();
-        
+
         for line in content.lines() {
             let line = line.trim();
             if line.is_empty() || line.starts_with('#') || line.starts_with('[') {
                 continue;
             }
-            
+
             if let Some((key, value)) = line.split_once('=') {
                 let key = key.trim();
                 let value = value.trim();
-                
+
                 match key {
                     "ringtone" | "ringtonePath" => {
                         config.ringtone_path = value.to_string();
@@ -516,37 +547,40 @@ impl FindMyPhonePluginConfig {
                 }
             }
         }
-        
+
         Ok(config)
     }
-    
+
     /// Save configuration to file
     pub fn save(&self, device_id: &str) -> io::Result<()> {
         let config_path = Self::get_config_path(device_id);
-        
+
         // Ensure directory exists
         if let Some(parent) = config_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        
+
         // Write config file in KDE config format
         let mut file = fs::File::create(&config_path)?;
         writeln!(file, "[General]")?;
         writeln!(file, "ringtone={}", self.ringtone_path)?;
-        
+
         eprintln!("✓ Saved findmyphone plugin config for device {}", device_id);
         eprintln!("  Path: {}", config_path.display());
         eprintln!("  Ringtone: {}", self.ringtone_path);
-        
+
         Ok(())
     }
-    
+
     /// Get the config file path for a device's findmyphone plugin
     fn get_config_path(device_id: &str) -> PathBuf {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-        PathBuf::from(format!("{}/.config/kdeconnect/{}/kdeconnect_findmyphone/config", home, device_id))
+        PathBuf::from(format!(
+            "{}/.config/kdeconnect/{}/kdeconnect_findmyphone/config",
+            home, device_id
+        ))
     }
-    
+
     /// Check if a config file exists for the device
     pub fn exists(device_id: &str) -> bool {
         Self::get_config_path(device_id).exists()
@@ -569,7 +603,7 @@ impl UrgencyLevel {
             _ => UrgencyLevel::Normal,
         }
     }
-    
+
     pub fn to_string(&self) -> &'static str {
         match self {
             UrgencyLevel::Low => "Low",
@@ -591,19 +625,19 @@ pub struct AppNotificationSetting {
 pub struct SendNotificationsPluginConfig {
     /// Only send persistent notifications
     pub persistent_only: bool,
-    
+
     /// Include notification body text
     pub include_body: bool,
-    
+
     /// Sync notification icons
     pub sync_icons: bool,
-    
+
     /// Minimum urgency level to send (0=Low, 1=Normal, 2=Critical)
     pub min_urgency: UrgencyLevel,
-    
+
     /// List of apps with specific settings (blocklist or allowlist)
     pub app_settings: Vec<AppNotificationSetting>,
-    
+
     /// If true, app_settings is a blocklist (block these apps)
     /// If false, app_settings is an allowlist (only allow these apps)
     pub use_blocklist: bool,
@@ -612,12 +646,12 @@ pub struct SendNotificationsPluginConfig {
 impl Default for SendNotificationsPluginConfig {
     fn default() -> Self {
         Self {
-            persistent_only: false,  // Send all notifications
-            include_body: true,      // Include body text
-            sync_icons: true,        // Sync icons
-            min_urgency: UrgencyLevel::Low,  // Send all urgency levels
-            app_settings: Vec::new(), // No app restrictions
-            use_blocklist: true,     // Default to blocklist mode
+            persistent_only: false,         // Send all notifications
+            include_body: true,             // Include body text
+            sync_icons: true,               // Sync icons
+            min_urgency: UrgencyLevel::Low, // Send all urgency levels
+            app_settings: Vec::new(),       // No app restrictions
+            use_blocklist: true,            // Default to blocklist mode
         }
     }
 }
@@ -626,37 +660,40 @@ impl SendNotificationsPluginConfig {
     /// Load configuration from file
     pub fn load(device_id: &str) -> io::Result<Self> {
         let config_path = Self::get_config_path(device_id);
-        
+
         if !config_path.exists() {
-            eprintln!("SendNotifications plugin config not found for device {}, using defaults", device_id);
+            eprintln!(
+                "SendNotifications plugin config not found for device {}, using defaults",
+                device_id
+            );
             return Ok(Self::default());
         }
-        
+
         let content = fs::read_to_string(&config_path)?;
-        
+
         // Parse the KDE config file format
         let mut config = Self::default();
         let mut in_general = false;
         let mut in_applications = false;
-        
+
         for line in content.lines() {
             let line = line.trim();
             if line.is_empty() || line.starts_with('#') {
                 continue;
             }
-            
+
             // Section headers
             if line.starts_with('[') && line.ends_with(']') {
-                let section = &line[1..line.len()-1];
+                let section = &line[1..line.len() - 1];
                 in_general = section == "General";
                 in_applications = section == "Applications";
                 continue;
             }
-            
+
             if let Some((key, value)) = line.split_once('=') {
                 let key = key.trim();
                 let value = value.trim();
-                
+
                 if in_general {
                     match key {
                         "persistentOnly" => {
@@ -687,22 +724,22 @@ impl SendNotificationsPluginConfig {
                 }
             }
         }
-        
+
         Ok(config)
     }
-    
+
     /// Save configuration to file
     pub fn save(&self, device_id: &str) -> io::Result<()> {
         let config_path = Self::get_config_path(device_id);
-        
+
         // Ensure directory exists
         if let Some(parent) = config_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        
+
         // Write config file in KDE config format
         let mut file = fs::File::create(&config_path)?;
-        
+
         // General section
         writeln!(file, "[General]")?;
         writeln!(file, "persistentOnly={}", self.persistent_only)?;
@@ -711,7 +748,7 @@ impl SendNotificationsPluginConfig {
         writeln!(file, "minUrgency={}", self.min_urgency as i32)?;
         writeln!(file, "useBlocklist={}", self.use_blocklist)?;
         writeln!(file)?;
-        
+
         // Applications section (if any app settings exist)
         if !self.app_settings.is_empty() {
             writeln!(file, "[Applications]")?;
@@ -719,25 +756,38 @@ impl SendNotificationsPluginConfig {
                 writeln!(file, "{}={}", app.app_name, app.enabled)?;
             }
         }
-        
-        eprintln!("✓ Saved sendnotifications plugin config for device {}", device_id);
+
+        eprintln!(
+            "✓ Saved sendnotifications plugin config for device {}",
+            device_id
+        );
         eprintln!("  Path: {}", config_path.display());
         eprintln!("  Persistent only: {}", self.persistent_only);
         eprintln!("  Include body: {}", self.include_body);
         eprintln!("  Sync icons: {}", self.sync_icons);
         eprintln!("  Min urgency: {:?}", self.min_urgency);
-        eprintln!("  Mode: {}", if self.use_blocklist { "Blocklist" } else { "Allowlist" });
+        eprintln!(
+            "  Mode: {}",
+            if self.use_blocklist {
+                "Blocklist"
+            } else {
+                "Allowlist"
+            }
+        );
         eprintln!("  App rules: {}", self.app_settings.len());
-        
+
         Ok(())
     }
-    
+
     /// Get the config file path for a device's sendnotifications plugin
     fn get_config_path(device_id: &str) -> PathBuf {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-        PathBuf::from(format!("{}/.config/kdeconnect/{}/kdeconnect_sendnotifications/config", home, device_id))
+        PathBuf::from(format!(
+            "{}/.config/kdeconnect/{}/kdeconnect_sendnotifications/config",
+            home, device_id
+        ))
     }
-    
+
     /// Check if a config file exists for the device
     pub fn exists(device_id: &str) -> bool {
         Self::get_config_path(device_id).exists()
@@ -767,7 +817,7 @@ impl PluginConfigs {
             sendnotifications: SendNotificationsPluginConfig::load(device_id).unwrap_or_default(),
         }
     }
-    
+
     /// Save all plugin configurations for a device
     pub fn save(&self, device_id: &str) -> io::Result<()> {
         self.share.save(device_id)?;
@@ -783,7 +833,7 @@ impl PluginConfigs {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_default_config() {
         let config = SharePluginConfig::default();

--- a/cosmic-ext-connect-applet/src/plugins/sms/app.rs
+++ b/cosmic-ext-connect-applet/src/plugins/sms/app.rs
@@ -1,11 +1,11 @@
 use async_stream::stream;
+use cosmic::iced::widget::scrollable;
 use cosmic::{
     Action, Application, ApplicationExt, Element, Task,
     app::Core,
     iced::{Length, Subscription},
     widget,
 };
-use cosmic::iced::widget::scrollable;
 use futures::StreamExt;
 use std::collections::HashMap;
 use tracing::{debug, error, info, warn};
@@ -95,10 +95,7 @@ impl Application for SmsWindow {
         let title = fl!("sms-window-title", device = device_name.as_str());
         app.core.window.header_title = title.clone().into();
 
-        let title_task = app.set_window_title(
-            title,
-            app.core.main_window_id().unwrap(),
-        );
+        let title_task = app.set_window_title(title, app.core.main_window_id().unwrap());
 
         (app, title_task)
     }
@@ -247,16 +244,24 @@ impl Application for SmsWindow {
 
                 // Update the conversation preview and timestamp so it sorts to
                 // the top of the list immediately without waiting for a server refresh.
-                if let Some(conv) = self.conversations.iter_mut().find(|c| c.thread_id == thread_id) {
+                if let Some(conv) = self
+                    .conversations
+                    .iter_mut()
+                    .find(|c| c.thread_id == thread_id)
+                {
                     conv.last_message = text.clone();
                     conv.timestamp = now;
                 }
-                self.conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+                self.conversations
+                    .sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
 
                 // Scroll the conversation list to the top so the moved item is visible.
                 let scroll_task = scrollable::scroll_to(
                     views::CONVERSATIONS_SCROLLABLE_ID.clone(),
-                    scrollable::AbsoluteOffset { x: Some(0.0), y: Some(0.0) },
+                    scrollable::AbsoluteOffset {
+                        x: Some(0.0),
+                        y: Some(0.0),
+                    },
                 );
 
                 return Task::batch(vec![
@@ -269,7 +274,10 @@ impl Application for SmsWindow {
             }
             SmsMessage::RefreshThread => {}
             SmsMessage::ProtocolEventReceived(event) => {
-                debug!("ProtocolEventReceived: {:?}", std::mem::discriminant(&event));
+                debug!(
+                    "ProtocolEventReceived: {:?}",
+                    std::mem::discriminant(&event)
+                );
                 self.handle_protocol_event(event);
             }
             SmsMessage::OpenNewChatDialog => {
@@ -327,7 +335,10 @@ impl SmsWindow {
     fn handle_protocol_event(&mut self, event: ProtocolEvent) {
         match event {
             ProtocolEvent::ConversationsReceived(conversations) => {
-                debug!("ConversationsReceived: {} conversations", conversations.len());
+                debug!(
+                    "ConversationsReceived: {} conversations",
+                    conversations.len()
+                );
 
                 // Capture selected new_* phone BEFORE we mutate merged
                 let pending_new_phone: Option<String> = self

--- a/cosmic-ext-connect-applet/src/plugins/sms/dbus.rs
+++ b/cosmic-ext-connect-applet/src/plugins/sms/dbus.rs
@@ -46,7 +46,10 @@ pub async fn fetch_conversations(device_id: &str) {
 }
 
 pub async fn request_conversation_messages(device_id: &str, thread_id: &str) {
-    debug!("request_conversation device={} thread={}", device_id, thread_id);
+    debug!(
+        "request_conversation device={} thread={}",
+        device_id, thread_id
+    );
     let Some(client) = get_client().await else {
         return;
     };

--- a/cosmic-ext-connect-applet/src/plugins/sms/utils.rs
+++ b/cosmic-ext-connect-applet/src/plugins/sms/utils.rs
@@ -95,7 +95,8 @@ fn decode_quoted_printable(input: &str) -> String {
     let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'=' && i + 2 < bytes.len()
+        if bytes[i] == b'='
+            && i + 2 < bytes.len()
             && bytes[i + 1].is_ascii_hexdigit()
             && bytes[i + 2].is_ascii_hexdigit()
         {

--- a/cosmic-ext-connect-applet/src/plugins/sms/views.rs
+++ b/cosmic-ext-connect-applet/src/plugins/sms/views.rs
@@ -1,9 +1,9 @@
 //! UI view implementations for the SMS window.
 
-use cosmic::widget::button::Catalog;
 use cosmic::Element;
 use cosmic::iced::{Alignment, Length};
 use cosmic::widget;
+use cosmic::widget::button::Catalog;
 
 use super::app::{SmsMessage, SmsWindow};
 use super::models::Conversation;
@@ -58,7 +58,11 @@ pub fn view_new_chat_dialog(app: &SmsWindow) -> Element<'_, SmsMessage> {
     let right = widget::Column::new()
         .spacing(spacing.space_s)
         .padding(spacing.space_l)
-        .push(widget::text(fl!("sms-new-chat-contacts")).size(16).font(cosmic::font::bold()))
+        .push(
+            widget::text(fl!("sms-new-chat-contacts"))
+                .size(16)
+                .font(cosmic::font::bold()),
+        )
         .push(view_contacts_list(app, &spacing))
         .width(Length::Fill);
 
@@ -82,7 +86,10 @@ fn view_new_chat_actions<'a>(
 
     widget::Row::new()
         .spacing(spacing.space_xs)
-        .push(widget::button::standard(fl!("sms-new-chat-cancel")).on_press(SmsMessage::CloseNewChatDialog))
+        .push(
+            widget::button::standard(fl!("sms-new-chat-cancel"))
+                .on_press(SmsMessage::CloseNewChatDialog),
+        )
         .push(widget::space::horizontal())
         .push(if start_button_enabled {
             widget::button::suggested(fl!("sms-new-chat-start")).on_press(SmsMessage::CreateNewChat)
@@ -97,7 +104,9 @@ fn view_contacts_list<'a>(
     spacing: &cosmic::cosmic_theme::Spacing,
 ) -> Element<'a, SmsMessage> {
     if app.contacts.is_empty() {
-        return widget::text(fl!("sms-new-chat-no-contacts")).size(12).into();
+        return widget::text(fl!("sms-new-chat-no-contacts"))
+            .size(12)
+            .into();
     }
 
     let mut contacts_list = widget::Column::new().spacing(spacing.space_xxs);
@@ -118,7 +127,10 @@ fn view_contacts_list<'a>(
         }
         contacts_list = contacts_list.push(
             widget::container(
-                widget::text(fl!("sms-new-chat-showing", count = (filtered_contacts.len() as i64)))
+                widget::text(fl!(
+                    "sms-new-chat-showing",
+                    count = (filtered_contacts.len() as i64)
+                ))
                 .size(11),
             )
             .padding([spacing.space_xs, 0, 0, 0]),
@@ -374,10 +386,7 @@ fn view_messages_list<'a>(
             widget::container(
                 widget::Column::new()
                     .push(widget::text(fl!("sms-waiting-for-messages")).size(14))
-                    .push(
-                        widget::text(fl!("sms-messages-will-appear"))
-                            .size(12),
-                    )
+                    .push(widget::text(fl!("sms-messages-will-appear")).size(12))
                     .spacing(spacing.space_xs)
                     .align_x(Alignment::Center),
             )
@@ -467,7 +476,7 @@ fn view_message_input<'a>(
         .push(
             widget::button::suggested(fl!("sms-send"))
                 .on_press(SmsMessage::SendMessage)
-                .class(crate::theme::accent_filled_button(app.accent_color))
+                .class(crate::theme::accent_filled_button(app.accent_color)),
         )
         .spacing(spacing.space_xs)
         .padding(spacing.space_s)

--- a/cosmic-ext-connect-applet/src/settings.rs
+++ b/cosmic-ext-connect-applet/src/settings.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate cosmic_ext_connect_applet;
 
+use cosmic::cosmic_config::{ConfigGet, ConfigSet};
 use cosmic::widget::button::Catalog;
 use cosmic::{
     Action, Application, ApplicationExt, Element, Task,
@@ -11,7 +12,6 @@ use cosmic::{
 use cosmic_ext_connect_applet::{backend, models::Device};
 use futures::StreamExt as _;
 use std::collections::HashMap;
-use cosmic::cosmic_config::{ConfigGet, ConfigSet};
 
 /// A desktop command stored as JSON: {id, name, command}
 type LocalCommand = serde_json::Value;
@@ -68,84 +68,84 @@ fn implemented_plugins() -> &'static [PluginInfo] {
     use std::sync::LazyLock;
     static PLUGINS: LazyLock<Vec<PluginInfo>> = LazyLock::new(|| {
         vec![
-        PluginInfo {
-            id: "battery",
-            name: fl!("plugin-battery-name"),
-            description: fl!("plugin-battery-desc"),
-            icon: "battery-full-symbolic",
-        },
-    PluginInfo {
-        id: "clipboard",
-        name: fl!("plugin-clipboard-name"),
-        description: fl!("plugin-clipboard-desc"),
-        icon: "edit-paste-symbolic",
-    },
-    PluginInfo {
-        id: "connectivity_report",
-        name: fl!("plugin-connectivity-name"),
-        description: fl!("plugin-connectivity-desc"),
-        icon: "network-cellular-symbolic",
-    },
-    PluginInfo {
-        id: "contacts",
-        name: fl!("plugin-contacts-name"),
-        description: fl!("plugin-contacts-desc"),
-        icon: "x-office-address-book-symbolic",
-    },
-    PluginInfo {
-        id: "findmyphone",
-        name: fl!("plugin-findmyphone-name"),
-        description: fl!("plugin-findmyphone-desc"),
-        icon: "audio-speakers-symbolic",
-    },
-    PluginInfo {
-        id: "mpris",
-        name: fl!("plugin-mpris-name"),
-        description: fl!("plugin-mpris-desc"),
-        icon: "media-playback-start-symbolic",
-    },
-    PluginInfo {
-        id: "notification",
-        name: fl!("plugin-notifications-name"),
-        description: fl!("plugin-notifications-desc"),
-        icon: "preferences-system-notifications-symbolic",
-    },
-    PluginInfo {
-        id: "ping",
-        name: fl!("plugin-ping-name"),
-        description: fl!("plugin-ping-desc"),
-        icon: "network-transmit-receive-symbolic",
-    },
-    PluginInfo {
-        id: "runcommand",
-        name: fl!("plugin-runcommand-name"),
-        description: fl!("plugin-runcommand-desc"),
-        icon: "utilities-terminal-symbolic",
-    },
-    PluginInfo {
-        id: "share",
-        name: fl!("plugin-share-name"),
-        description: fl!("plugin-share-desc"),
-        icon: "document-send-symbolic",
-    },
-    PluginInfo {
-        id: "sms",
-        name: fl!("plugin-sms-name"),
-        description: fl!("plugin-sms-desc"),
-        icon: "mail-message-new-symbolic",
-    },
-    PluginInfo {
-        id: "systemvolume",
-        name: fl!("plugin-systemvolume-name"),
-        description: fl!("plugin-systemvolume-desc"),
-        icon: "audio-volume-high-symbolic",
-    },
-    PluginInfo {
-        id: "telephony",
-        name: fl!("plugin-telephony-name"),
-        description: fl!("plugin-telephony-desc"),
-        icon: "phone-symbolic",
-    },
+            PluginInfo {
+                id: "battery",
+                name: fl!("plugin-battery-name"),
+                description: fl!("plugin-battery-desc"),
+                icon: "battery-full-symbolic",
+            },
+            PluginInfo {
+                id: "clipboard",
+                name: fl!("plugin-clipboard-name"),
+                description: fl!("plugin-clipboard-desc"),
+                icon: "edit-paste-symbolic",
+            },
+            PluginInfo {
+                id: "connectivity_report",
+                name: fl!("plugin-connectivity-name"),
+                description: fl!("plugin-connectivity-desc"),
+                icon: "network-cellular-symbolic",
+            },
+            PluginInfo {
+                id: "contacts",
+                name: fl!("plugin-contacts-name"),
+                description: fl!("plugin-contacts-desc"),
+                icon: "x-office-address-book-symbolic",
+            },
+            PluginInfo {
+                id: "findmyphone",
+                name: fl!("plugin-findmyphone-name"),
+                description: fl!("plugin-findmyphone-desc"),
+                icon: "audio-speakers-symbolic",
+            },
+            PluginInfo {
+                id: "mpris",
+                name: fl!("plugin-mpris-name"),
+                description: fl!("plugin-mpris-desc"),
+                icon: "media-playback-start-symbolic",
+            },
+            PluginInfo {
+                id: "notification",
+                name: fl!("plugin-notifications-name"),
+                description: fl!("plugin-notifications-desc"),
+                icon: "preferences-system-notifications-symbolic",
+            },
+            PluginInfo {
+                id: "ping",
+                name: fl!("plugin-ping-name"),
+                description: fl!("plugin-ping-desc"),
+                icon: "network-transmit-receive-symbolic",
+            },
+            PluginInfo {
+                id: "runcommand",
+                name: fl!("plugin-runcommand-name"),
+                description: fl!("plugin-runcommand-desc"),
+                icon: "utilities-terminal-symbolic",
+            },
+            PluginInfo {
+                id: "share",
+                name: fl!("plugin-share-name"),
+                description: fl!("plugin-share-desc"),
+                icon: "document-send-symbolic",
+            },
+            PluginInfo {
+                id: "sms",
+                name: fl!("plugin-sms-name"),
+                description: fl!("plugin-sms-desc"),
+                icon: "mail-message-new-symbolic",
+            },
+            PluginInfo {
+                id: "systemvolume",
+                name: fl!("plugin-systemvolume-name"),
+                description: fl!("plugin-systemvolume-desc"),
+                icon: "audio-volume-high-symbolic",
+            },
+            PluginInfo {
+                id: "telephony",
+                name: fl!("plugin-telephony-name"),
+                description: fl!("plugin-telephony-desc"),
+                icon: "phone-symbolic",
+            },
         ]
     });
     &PLUGINS
@@ -252,7 +252,7 @@ impl Application for SettingsApp {
         let mut app = Self {
             core,
             accent_color: cosmic_ext_connect_applet::theme::try_load_cosmic_accent()
-               .unwrap_or(cosmic_ext_connect_applet::theme::FALLBACK_TEAL),
+                .unwrap_or(cosmic_ext_connect_applet::theme::FALLBACK_TEAL),
             active_tab: Tab::PairedDevices,
             devices: Vec::new(),
             selected_device: None,
@@ -265,10 +265,8 @@ impl Application for SettingsApp {
 
         app.core.window.header_title = fl!("settings-title").into();
 
-        let title_task = app.set_window_title(
-            fl!("settings-title"),
-            app.core.main_window_id().unwrap(),
-        );
+        let title_task =
+            app.set_window_title(fl!("settings-title"), app.core.main_window_id().unwrap());
 
         let load_task = Task::perform(
             async {
@@ -280,10 +278,9 @@ impl Application for SettingsApp {
             |devices| Action::App(Message::DevicesLoaded(devices)),
         );
 
-        let cmds_task = Task::perform(
-            async { load_run_commands() },
-            |cmds| Action::App(Message::RunCommandsLoaded(cmds)),
-        );
+        let cmds_task = Task::perform(async { load_run_commands() }, |cmds| {
+            Action::App(Message::RunCommandsLoaded(cmds))
+        });
 
         (app, Task::batch(vec![title_task, load_task, cmds_task]))
     }
@@ -344,10 +341,9 @@ impl Application for SettingsApp {
                 let trigger_broadcast = tab == Tab::AvailableDevices;
                 self.active_tab = tab;
                 if trigger_broadcast {
-                    return Task::perform(
-                        async { backend::fetch_devices().await },
-                        |devices| Action::App(Message::DevicesLoaded(devices)),
-                    );
+                    return Task::perform(async { backend::fetch_devices().await }, |devices| {
+                        Action::App(Message::DevicesLoaded(devices))
+                    });
                 }
             }
 
@@ -374,9 +370,7 @@ impl Application for SettingsApp {
                     let pid = plugin_id;
                     return Task::perform(
                         async move {
-                            if let Err(e) =
-                                backend::set_plugin_enabled(did, pid, enabled).await
-                            {
+                            if let Err(e) = backend::set_plugin_enabled(did, pid, enabled).await {
                                 eprintln!("[settings] set_plugin_enabled failed: {:?}", e);
                             }
                         },
@@ -386,10 +380,9 @@ impl Application for SettingsApp {
             }
 
             Message::Refresh => {
-                return Task::perform(
-                    async { backend::fetch_devices().await },
-                    |devices| Action::App(Message::DevicesLoaded(devices)),
-                );
+                return Task::perform(async { backend::fetch_devices().await }, |devices| {
+                    Action::App(Message::DevicesLoaded(devices))
+                });
             }
 
             Message::PairDevice(device_id) => {
@@ -431,10 +424,9 @@ impl Application for SettingsApp {
                         | kdeconnect_dbus_client::ServiceEvent::DevicePaired(..)
                 );
                 if needs_refresh {
-                    return Task::perform(
-                        async { backend::fetch_devices().await },
-                        |devices| Action::App(Message::DevicesLoaded(devices)),
-                    );
+                    return Task::perform(async { backend::fetch_devices().await }, |devices| {
+                        Action::App(Message::DevicesLoaded(devices))
+                    });
                 }
             }
             Message::RunCommandsLoaded(cmds) => {
@@ -507,17 +499,16 @@ impl Application for SettingsApp {
 // ---------------------------------------------------------------------------
 
 impl SettingsApp {
-    fn view_tab_bar<'a>(
-        &'a self,
-        spacing: &cosmic::cosmic_theme::Spacing,
-    ) -> Element<'a, Message> {
+    fn view_tab_bar<'a>(&'a self, spacing: &cosmic::cosmic_theme::Spacing) -> Element<'a, Message> {
         let paired_btn = if self.active_tab == Tab::PairedDevices {
             widget::button::standard(fl!("settings-tab-paired"))
                 .on_press(Message::SelectTab(Tab::PairedDevices))
         } else {
             widget::button::text(fl!("settings-tab-paired"))
                 .on_press(Message::SelectTab(Tab::PairedDevices))
-                .class(cosmic_ext_connect_applet::theme::accent_link_button(self.accent_color))
+                .class(cosmic_ext_connect_applet::theme::accent_link_button(
+                    self.accent_color,
+                ))
         };
 
         let available_btn = if self.active_tab == Tab::AvailableDevices {
@@ -526,7 +517,9 @@ impl SettingsApp {
         } else {
             widget::button::text(fl!("settings-tab-available"))
                 .on_press(Message::SelectTab(Tab::AvailableDevices))
-                .class(cosmic_ext_connect_applet::theme::accent_link_button(self.accent_color))
+                .class(cosmic_ext_connect_applet::theme::accent_link_button(
+                    self.accent_color,
+                ))
         };
 
         widget::Row::new()
@@ -559,11 +552,8 @@ impl SettingsApp {
 
         if paired.is_empty() {
             col = col.push(
-                widget::container(
-                    widget::text(fl!("paired-devices-none"))
-                        .size(12),
-                )
-                .padding(spacing.space_s),
+                widget::container(widget::text(fl!("paired-devices-none")).size(12))
+                    .padding(spacing.space_s),
             );
         } else {
             for device in &paired {
@@ -578,7 +568,13 @@ impl SettingsApp {
                 let item = widget::Row::new()
                     .spacing(spacing.space_s)
                     .align_y(Alignment::Center)
-                    .push(widget::icon(cosmic_ext_connect_applet::theme::accent_icon(device.device_icon(), self.accent_color)).size(20))
+                    .push(
+                        widget::icon(cosmic_ext_connect_applet::theme::accent_icon(
+                            device.device_icon(),
+                            self.accent_color,
+                        ))
+                        .size(20),
+                    )
                     .push(
                         widget::Column::new()
                             .spacing(2)
@@ -593,7 +589,13 @@ impl SettingsApp {
                             )
                             .width(Length::Fill),
                     )
-                    .push(widget::icon(cosmic_ext_connect_applet::theme::accent_icon(status_icon, self.accent_color)).size(14));
+                    .push(
+                        widget::icon(cosmic_ext_connect_applet::theme::accent_icon(
+                            status_icon,
+                            self.accent_color,
+                        ))
+                        .size(14),
+                    );
 
                 let accent = self.accent_color;
                 let btn = widget::button::custom(item)
@@ -681,10 +683,8 @@ impl SettingsApp {
 
         if self.selected_device.is_none() {
             col = col.push(
-                widget::container(
-                    widget::text(fl!("paired-plugins-hint")).size(14),
-                )
-                .padding(spacing.space_l),
+                widget::container(widget::text(fl!("paired-plugins-hint")).size(14))
+                    .padding(spacing.space_l),
             );
             return widget::scrollable(col).height(Length::Fill).into();
         }
@@ -759,12 +759,12 @@ impl SettingsApp {
                         .font(cosmic::font::bold())
                         .width(Length::Fill),
                 )
-                .push(widget::button::standard(fl!("settings-scan-again")).on_press(Message::Refresh)),
+                .push(
+                    widget::button::standard(fl!("settings-scan-again")).on_press(Message::Refresh),
+                ),
         );
         col = col.push(widget::divider::horizontal::default());
-        col = col.push(
-            widget::text(fl!("available-devices-hint")).size(13),
-        );
+        col = col.push(widget::text(fl!("available-devices-hint")).size(13));
 
         if available.is_empty() {
             col = col.push(
@@ -777,11 +777,11 @@ impl SettingsApp {
                                 .size(16)
                                 .font(cosmic::font::bold()),
                         )
+                        .push(widget::text(fl!("available-devices-none-hint")).size(13))
                         .push(
-                            widget::text(fl!("available-devices-none-hint"))
-                            .size(13),
+                            widget::button::standard(fl!("settings-scan-again"))
+                                .on_press(Message::Refresh),
                         )
-                        .push(widget::button::standard(fl!("settings-scan-again")).on_press(Message::Refresh))
                         .align_x(Alignment::Center),
                 )
                 .padding([spacing.space_xl, spacing.space_m])
@@ -813,7 +813,9 @@ impl SettingsApp {
                     } else {
                         widget::button::suggested(fl!("available-devices-pair"))
                             .on_press(Message::PairDevice(device_id))
-                            .class(cosmic_ext_connect_applet::theme::accent_filled_button(self.accent_color))
+                            .class(cosmic_ext_connect_applet::theme::accent_filled_button(
+                                self.accent_color,
+                            ))
                     });
 
                 col = col.push(
@@ -880,14 +882,19 @@ impl SettingsApp {
                 .width(Length::Fill),
         );
         col = col.push(
-            widget::text_input(fl!("run-commands-command-placeholder"), &self.new_cmd_command)
-                .on_input(Message::NewRunCommandCommand)
-                .width(Length::Fill),
+            widget::text_input(
+                fl!("run-commands-command-placeholder"),
+                &self.new_cmd_command,
+            )
+            .on_input(Message::NewRunCommandCommand)
+            .width(Length::Fill),
         );
         col = col.push(
             widget::button::suggested(fl!("run-commands-add-button"))
                 .on_press(Message::AddRunCommand)
-                .class(cosmic_ext_connect_applet::theme::accent_filled_button(self.accent_color)),
+                .class(cosmic_ext_connect_applet::theme::accent_filled_button(
+                    self.accent_color,
+                )),
         );
 
         widget::container(col)
@@ -916,7 +923,6 @@ fn uuid_v4() -> String {
 }
 
 fn main() -> cosmic::iced::Result {
-    let settings = cosmic::app::Settings::default()
-        .size(cosmic::iced::Size::new(740.0, 540.0));
+    let settings = cosmic::app::Settings::default().size(cosmic::iced::Size::new(740.0, 540.0));
     cosmic::app::run::<SettingsApp>(settings, ())
 }

--- a/cosmic-ext-connect-applet/src/theme.rs
+++ b/cosmic-ext-connect-applet/src/theme.rs
@@ -124,8 +124,6 @@ pub fn accent_icon(name: &str, accent: cosmic::iced::Color) -> cosmic::widget::i
     cosmic::widget::icon::from_name(name)
         .path()
         .and_then(|path| std::fs::read_to_string(path).ok())
-        .map(|svg| {
-            cosmic::widget::icon::from_svg_bytes(svg.replace("#232323", &hex).into_bytes())
-        })
+        .map(|svg| cosmic::widget::icon::from_svg_bytes(svg.replace("#232323", &hex).into_bytes()))
         .unwrap_or_else(|| cosmic::widget::icon::from_name(name).handle())
 }

--- a/cosmic-ext-connect-applet/src/ui/popup.rs
+++ b/cosmic-ext-connect-applet/src/ui/popup.rs
@@ -1,10 +1,10 @@
 use crate::messages::Message;
 use crate::models::Device;
+use crate::theme;
 use cosmic::app::Core;
 use cosmic::iced::{Alignment, Length};
 use cosmic::{Element, widget};
 use std::collections::HashMap;
-use crate::theme;
 
 /// Build the popup view using the real application Core so popup_container
 /// has proper applet context, theme, and sizing.
@@ -124,7 +124,12 @@ pub fn create_popup_view<'a>(
         );
 
         for device in paired_devices {
-            content = content.push(create_device_card(device, &spacing, expanded_device, accent_color));
+            content = content.push(create_device_card(
+                device,
+                &spacing,
+                expanded_device,
+                accent_color,
+            ));
         }
     }
 
@@ -141,7 +146,7 @@ pub fn create_popup_view<'a>(
 fn create_device_card<'a>(
     device: &'a Device,
     spacing: &cosmic::cosmic_theme::Spacing,
-    expanded_device: Option<&'a String>,
+    expanded_device: Option<&String>,
     accent_color: cosmic::iced::Color,
 ) -> Element<'a, Message> {
     let is_expanded = expanded_device == Some(&device.id);
@@ -157,26 +162,33 @@ fn create_device_card<'a>(
         name_row = name_row.push(widget::text(fl!("devices-offline")).size(11));
     } else {
         if let Some(signal_icon) = device.signal_icon() {
-            name_row = name_row.push(widget::icon(theme::accent_icon(signal_icon, accent_color)).size(16));
+            name_row =
+                name_row.push(widget::icon(theme::accent_icon(signal_icon, accent_color)).size(16));
         }
         if let Some(level) = device.battery_level {
             name_row = name_row.push(
                 widget::Row::new()
                     .spacing(2)
                     .align_y(Alignment::Center)
-                    .push(widget::icon(theme::accent_icon(device.battery_icon(), accent_color)).size(16))
+                    .push(
+                        widget::icon(theme::accent_icon(device.battery_icon(), accent_color))
+                            .size(16),
+                    )
                     .push(widget::text(format!("{}%", level)).size(11)),
             );
         }
     }
 
     name_row = name_row.push(
-        widget::button::icon(theme::accent_icon(
-            if is_expanded { "go-up-symbolic" } else { "go-down-symbolic" },
+        widget::icon(theme::accent_icon(
+            if is_expanded {
+                "go-up-symbolic"
+            } else {
+                "go-down-symbolic"
+            },
             accent_color,
         ))
-        .on_press(Message::ToggleDeviceMenu(device.id.clone()))
-        .class(cosmic::theme::Button::Icon),
+        .size(16),
     );
 
     let device_button = widget::button::custom(name_row)
@@ -243,7 +255,9 @@ fn create_device_card<'a>(
                         .class(theme::accent_link_button(accent_color)),
                 );
                 menu_items = menu_items.push_maybe(if let Some(progress) = device.share_progress {
-                    Some(widget::progress_bar::determinate_linear(progress as f32 / 100.0))
+                    Some(widget::progress_bar::determinate_linear(
+                        progress as f32 / 100.0,
+                    ))
                 } else {
                     None
                 });

--- a/justfile
+++ b/justfile
@@ -134,7 +134,8 @@ uninstall:
     rm -vf {{PREFIX}}/bin/cosmic-ext-connect-applet
     rm -vf {{PREFIX}}/bin/cosmic-ext-connect-settings
     rm -vf {{PREFIX}}/bin/cosmic-ext-connect-sms
-    rm -vf {{XDG_CONFIG}}/kdeconnect/*
+    rm -vf {{PREFIX}}/bin/kdeconnect-applet-debug
+    rm -rvf {{XDG_CONFIG}}/kdeconnect/*
     rm -vf {{XDG_CONFIG}}/systemd/user/kdeconnect.service
     rm -vf {{XDG_CONFIG}}/autostart/{{APPID}}.daemon.desktop
     rm -rvf {{PREFIX}}/share/kdeconnect/*

--- a/kdeconnect-core/src/event.rs
+++ b/kdeconnect-core/src/event.rs
@@ -39,7 +39,7 @@ pub enum CoreEvent {
     Error(String),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum AppEvent {
     Broadcasting,
     Disconnect(DeviceId),
@@ -52,6 +52,12 @@ pub enum AppEvent {
     MprisAction((DeviceId, String, MprisAction)),
     SendMprisRequest((DeviceId, MprisRequest)),
     SendPacket(DeviceId, ProtocolPacket),
+    /// Queue a packet and report whether a live transport writer accepted it.
+    SendPacketWithReply(
+        DeviceId,
+        ProtocolPacket,
+        tokio::sync::oneshot::Sender<Result<(), String>>,
+    ),
     PushLocalCommands(DeviceId),
     SetPluginEnabled {
         device_id: DeviceId,

--- a/kdeconnect-core/src/lib.rs
+++ b/kdeconnect-core/src/lib.rs
@@ -6,7 +6,7 @@ use tokio::{
     select,
     sync::{Mutex, mpsc},
 };
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::{
     device::{Device, DeviceId, DeviceManager},
@@ -462,15 +462,49 @@ impl KdeConnectCore {
             }
             AppEvent::SendPacket(device_id, packet) => {
                 info!("Sending packet to device: {}", device_id);
+                if let Some(plugin_id) =
+                    crate::plugin_interface::packet_plugin_id(&packet.packet_type)
+                    && !self
+                        .plugin_registry
+                        .is_plugin_enabled(&device_id.0, plugin_id)
+                        .await
+                {
+                    warn!(
+                        "Not sending {:?} to {}: plugin '{}' is disabled",
+                        packet.packet_type, device_id, plugin_id
+                    );
+                    return;
+                }
                 if let Some(sender) = guard.get(&device_id) {
-                    let _ = sender.send(packet);
+                    if sender.send(packet).is_err() {
+                        warn!("Failed to queue packet for {}: writer closed", device_id);
+                    }
                 } else {
-                    debug!(
+                    warn!(
                         "No sender for device {} — available: {:?}",
                         device_id,
                         guard.keys().collect::<Vec<_>>()
                     );
                 }
+            }
+            AppEvent::SendPacketWithReply(device_id, packet, reply) => {
+                info!("Sending acknowledged packet to device: {}", device_id);
+                let result = if let Some(plugin_id) =
+                    crate::plugin_interface::packet_plugin_id(&packet.packet_type)
+                    && !self
+                        .plugin_registry
+                        .is_plugin_enabled(&device_id.0, plugin_id)
+                        .await
+                {
+                    Err(format!("Plugin '{plugin_id}' is disabled for {device_id}"))
+                } else if let Some(sender) = guard.get(&device_id) {
+                    sender.send(packet).map_err(|_| {
+                        format!("Connection writer is closed for device {device_id}")
+                    })
+                } else {
+                    Err(format!("No active connection for device {device_id}"))
+                };
+                let _ = reply.send(result);
             }
             AppEvent::PushLocalCommands(device_id) => {
                 plugins::run_command::send_command_list(&device_id, self.event_tx.clone()).await;

--- a/kdeconnect-core/src/lib.rs
+++ b/kdeconnect-core/src/lib.rs
@@ -20,12 +20,12 @@ use crate::{
 };
 
 pub mod config;
-pub mod plugin_config;
 pub(crate) mod crypto;
 pub mod device;
 pub mod event;
 pub mod filetransfer;
 pub(crate) mod pairing;
+pub mod plugin_config;
 pub(crate) mod plugin_interface;
 pub mod plugins;
 pub(crate) mod protocol;
@@ -131,10 +131,7 @@ impl KdeConnectCore {
     pub async fn run_event_loop(&mut self) {
         info!("Starting KdeConnect event loop");
 
-        plugins::mpris::monitor_mpris(
-            (*self.device_manager).clone(),
-            self.event_tx.clone(),
-        );
+        plugins::mpris::monitor_mpris((*self.device_manager).clone(), self.event_tx.clone());
 
         loop {
             select! {
@@ -214,12 +211,11 @@ impl KdeConnectCore {
                     if let Some(sender) = guard.get(&device_id) {
                         let mpris_pkt = ProtocolPacket::new(
                             PacketType::MprisRequest,
-                            serde_json::to_value(
-                                crate::plugins::mpris::MprisRequest {
-                                    request_player_list: Some(true),
-                                    ..Default::default()
-                                }
-                            ).unwrap(),
+                            serde_json::to_value(crate::plugins::mpris::MprisRequest {
+                                request_player_list: Some(true),
+                                ..Default::default()
+                            })
+                            .unwrap(),
                         );
                         let _ = sender.send(mpris_pkt);
                     }
@@ -317,8 +313,12 @@ impl KdeConnectCore {
                     // Send our local command list so the Android app shows
                     // the Run Command option (requires canAddCommand: true).
                     plugins::run_command::send_command_list(&id, self.event_tx.clone()).await;
-                    
-                    if self.plugin_registry.is_plugin_enabled(&id.0, "systemvolume").await {
+
+                    if self
+                        .plugin_registry
+                        .is_plugin_enabled(&id.0, "systemvolume")
+                        .await
+                    {
                         plugins::systemvolume::on_device_connect(id.clone(), self.event_tx.clone());
                     }
                 }
@@ -343,9 +343,15 @@ impl KdeConnectCore {
                                     // user can still initiate pairing normally from the settings app.
                                     self.pending_pair.lock().await.remove(&id);
                                     if device.pair_state == crate::device::PairState::Paired {
-                                        info!("[core] Phone unpairing from us — cleaning up {}", id);
+                                        info!(
+                                            "[core] Phone unpairing from us — cleaning up {}",
+                                            id
+                                        );
                                         self.device_manager
-                                            .update_pair_state(&id, crate::device::PairState::NotPaired)
+                                            .update_pair_state(
+                                                &id,
+                                                crate::device::PairState::NotPaired,
+                                            )
                                             .await;
                                         cleanup_device_data(&id.0).await;
                                         let conn_event = ConnectionEvent::PairStateChanged((
@@ -355,7 +361,10 @@ impl KdeConnectCore {
                                         let _ = self.conn_tx.send(conn_event.clone());
                                         let _ = self.mpris_conn_tx.send(conn_event);
                                     } else {
-                                        info!("[core] pair:false from {} — device not paired, ignoring", id);
+                                        info!(
+                                            "[core] pair:false from {} — device not paired, ignoring",
+                                            id
+                                        );
                                     }
                                 } else {
                                     let device_name = device.name.clone();
@@ -498,9 +507,9 @@ impl KdeConnectCore {
                 {
                     Err(format!("Plugin '{plugin_id}' is disabled for {device_id}"))
                 } else if let Some(sender) = guard.get(&device_id) {
-                    sender.send(packet).map_err(|_| {
-                        format!("Connection writer is closed for device {device_id}")
-                    })
+                    sender
+                        .send(packet)
+                        .map_err(|_| format!("Connection writer is closed for device {device_id}"))
                 } else {
                     Err(format!("No active connection for device {device_id}"))
                 };
@@ -670,7 +679,10 @@ impl KdeConnectCore {
                 // The phone processes capabilities only during connection setup.
                 if guard.remove(&device_id).is_some() {
                     self.conn_id_map.lock().await.remove(&device_id);
-                    info!("[plugin] dropped connection to {} — phone will reconnect with updated capabilities", device_id);
+                    info!(
+                        "[plugin] dropped connection to {} — phone will reconnect with updated capabilities",
+                        device_id
+                    );
                 }
             }
         };
@@ -691,7 +703,11 @@ async fn cleanup_device_data(device_id: &str) {
             .join(format!("{}_plugins.json", device_id));
         if let Err(e) = tokio::fs::remove_file(&plugin_file).await {
             if e.kind() != std::io::ErrorKind::NotFound {
-                tracing::warn!("[cleanup] failed to remove plugin config for {}: {}", device_id, e);
+                tracing::warn!(
+                    "[cleanup] failed to remove plugin config for {}: {}",
+                    device_id,
+                    e
+                );
             }
         }
     }
@@ -701,7 +717,11 @@ async fn cleanup_device_data(device_id: &str) {
         let cache_dir = data_dir.join("kdeconnect").join(device_id);
         if let Err(e) = tokio::fs::remove_dir_all(&cache_dir).await {
             if e.kind() != std::io::ErrorKind::NotFound {
-                tracing::warn!("[cleanup] failed to remove cache dir for {}: {}", device_id, e);
+                tracing::warn!(
+                    "[cleanup] failed to remove cache dir for {}: {}",
+                    device_id,
+                    e
+                );
             }
         }
     }

--- a/kdeconnect-core/src/pairing.rs
+++ b/kdeconnect-core/src/pairing.rs
@@ -74,7 +74,10 @@ impl PairingManager {
             .update_pair_state(&id, PairState::Requested)
             .await;
 
-        info!("Pair request received from {} — awaiting user decision", name);
+        info!(
+            "Pair request received from {} — awaiting user decision",
+            name
+        );
         Ok(true)
     }
 

--- a/kdeconnect-core/src/plugin_interface.rs
+++ b/kdeconnect-core/src/plugin_interface.rs
@@ -12,7 +12,7 @@ use crate::{
     GLOBAL_CONFIG,
     device::Device,
     event::{ConnectionEvent, CoreEvent},
-    filetransfer::{send_progress, TransferAdapter},
+    filetransfer::{TransferAdapter, send_progress},
     plugins::{
         self,
         battery::Battery,
@@ -123,10 +123,7 @@ impl PluginRegistry {
     ) {
         // Gate on plugin enabled state before doing any work.
         if let Some(plugin_id) = packet_plugin_id(&packet.packet_type) {
-            if !self
-                .is_plugin_enabled(&device.device_id.0, plugin_id)
-                .await
-            {
+            if !self.is_plugin_enabled(&device.device_id.0, plugin_id).await {
                 debug!(
                     "[plugin_registry] packet {:?} skipped — plugin '{}' disabled for {}",
                     packet.packet_type, plugin_id, device.device_id
@@ -469,7 +466,8 @@ fn decode_quoted_printable(input: &str) -> String {
     let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'=' && i + 2 < bytes.len()
+        if bytes[i] == b'='
+            && i + 2 < bytes.len()
             && bytes[i + 1].is_ascii_hexdigit()
             && bytes[i + 2].is_ascii_hexdigit()
         {

--- a/kdeconnect-core/src/plugin_interface.rs
+++ b/kdeconnect-core/src/plugin_interface.rs
@@ -32,7 +32,7 @@ pub trait Plugin: Sync + Send {
 
 /// Maps a PacketType to the logical plugin ID used in settings.
 /// Returns None for core packets (Identity, Pair) that are never gated.
-fn packet_plugin_id(pt: &PacketType) -> Option<&'static str> {
+pub(crate) fn packet_plugin_id(pt: &PacketType) -> Option<&'static str> {
     match pt {
         PacketType::Battery | PacketType::BatteryRequest => Some("battery"),
         PacketType::Clipboard | PacketType::ClipboardConnect => Some("clipboard"),
@@ -229,19 +229,16 @@ impl PluginRegistry {
                 }
             }
             PacketType::ClipboardConnect => {
-                if let Ok(clipboard) = serde_json::from_value::<Clipboard>(body)
-                    && let Some(timestamp) = clipboard.timestamp
-                {
-                    let local_ts = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_millis() as u64)
-                        .unwrap_or(0);
-                    if timestamp > 0 && timestamp >= local_ts {
-                        info!("Clipboard sync on connect accepted (ts={} local={})", timestamp, local_ts);
-                        clipboard.received_packet(connection_tx).await;
-                    } else {
-                        info!("Clipboard sync on connect ignored — stale timestamp (ts={} local={})", timestamp, local_ts);
-                    }
+                if let Ok(clipboard) = serde_json::from_value::<Clipboard>(body) {
+                    // The remote timestamp cannot be compared with `now`: network
+                    // latency makes it older by definition and clock skew makes the
+                    // comparison meaningless. The applet tracks the actual local
+                    // clipboard value and suppresses echo loops.
+                    info!(
+                        "Clipboard sync on connect accepted (remote_ts={:?})",
+                        clipboard.timestamp
+                    );
+                    clipboard.received_packet(connection_tx).await;
                 }
             }
             PacketType::MousePadKeyboardState => {

--- a/kdeconnect-core/src/plugins/contacts.rs
+++ b/kdeconnect-core/src/plugins/contacts.rs
@@ -10,7 +10,8 @@ fn decode_quoted_printable(input: &str) -> String {
     let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'=' && i + 2 < bytes.len()
+        if bytes[i] == b'='
+            && i + 2 < bytes.len()
             && bytes[i + 1].is_ascii_hexdigit()
             && bytes[i + 2].is_ascii_hexdigit()
         {

--- a/kdeconnect-core/src/plugins/mpris.rs
+++ b/kdeconnect-core/src/plugins/mpris.rs
@@ -226,7 +226,10 @@ pub fn get_all_mpris_player_names() -> Vec<String> {
         Err(_) => return vec![],
     };
     match finder.find_all() {
-        Ok(players) => players.into_iter().map(|p| p.identity().to_string()).collect(),
+        Ok(players) => players
+            .into_iter()
+            .map(|p| p.identity().to_string())
+            .collect(),
         Err(_) => vec![],
     }
 }
@@ -397,7 +400,7 @@ pub fn monitor_mpris(
     let ctx_sup = core_tx.clone();
 
     tokio::task::spawn_blocking(move || {
-       let (call_tx, call_rx) = std::sync::mpsc::sync_channel::<bool>(1);
+        let (call_tx, call_rx) = std::sync::mpsc::sync_channel::<bool>(1);
         TELEPHONY_CALL_TX.set(call_tx).ok();
 
         // Holds Player objects paused for an active call — keeping them alive
@@ -594,7 +597,10 @@ impl PhoneMprisPlayer {
         self.send_request(request).await;
     }
 
-    async fn play_pause(&self, #[zbus(signal_emitter)] emitter: zbus::object_server::SignalEmitter<'_>) {
+    async fn play_pause(
+        &self,
+        #[zbus(signal_emitter)] emitter: zbus::object_server::SignalEmitter<'_>,
+    ) {
         let mut state = self.player_state.write().await;
         let is_playing = state.is_playing.unwrap_or(false);
         state.is_playing = Some(!is_playing);

--- a/kdeconnect-core/src/plugins/run_command.rs
+++ b/kdeconnect-core/src/plugins/run_command.rs
@@ -102,7 +102,10 @@ impl RunCommand {
             match serde_json::from_str(&self.command_list) {
                 Ok(map) => map,
                 Err(e) => {
-                    warn!("[runcommand] failed to parse commandList from {}: {}", device.device_id, e);
+                    warn!(
+                        "[runcommand] failed to parse commandList from {}: {}",
+                        device.device_id, e
+                    );
                     return;
                 }
             };
@@ -154,10 +157,7 @@ impl RunCommandRequest {
             // Phone is asking us to execute a local command by its UUID key.
             let commands = load_local_commands();
             if let Some(cmd) = commands.iter().find(|c| c.id == *key) {
-                info!(
-                    "[runcommand] executing '{}': {}",
-                    cmd.name, cmd.command
-                );
+                info!("[runcommand] executing '{}': {}", cmd.name, cmd.command);
                 let result = if std::env::var("FLATPAK_ID").is_ok() {
                     std::process::Command::new("flatpak-spawn")
                         .arg("--host")
@@ -171,8 +171,7 @@ impl RunCommandRequest {
                         .arg(&cmd.command)
                         .spawn()
                 };
-                if let Err(e) = result
-                {
+                if let Err(e) = result {
                     warn!("[runcommand] failed to spawn '{}': {}", cmd.name, e);
                 }
             } else {
@@ -212,8 +211,8 @@ pub async fn send_command_list(
             serde_json::json!({ "name": cmd.name, "command": cmd.command }),
         );
     }
-    let command_list_str = serde_json::to_string(&serde_json::Value::Object(map))
-        .unwrap_or_else(|_| "{}".to_string());
+    let command_list_str =
+        serde_json::to_string(&serde_json::Value::Object(map)).unwrap_or_else(|_| "{}".to_string());
 
     info!(
         "[runcommand] sending {} command(s) to {}",

--- a/kdeconnect-core/src/plugins/systemvolume.rs
+++ b/kdeconnect-core/src/plugins/systemvolume.rs
@@ -90,8 +90,10 @@ static PA_CONNECTIONS: std::sync::LazyLock<Mutex<std::collections::HashMap<Strin
 
 impl SystemVolumeRequest {
     pub async fn handle(&self, device: &Device, _core_tx: mpsc::UnboundedSender<CoreEvent>) {
-        info!("[systemvolume] handle called: request_sinks={:?} name={:?} volume={:?} muted={:?}",
-            self.request_sinks, self.name, self.volume, self.muted);
+        info!(
+            "[systemvolume] handle called: request_sinks={:?} name={:?} volume={:?} muted={:?}",
+            self.request_sinks, self.name, self.volume, self.muted
+        );
         let conn = {
             let map = PA_CONNECTIONS.lock().unwrap();
             map.get(&device.device_id.0).cloned()
@@ -336,9 +338,7 @@ fn enumerate_sinks(mainloop: &mut Mainloop, context: &Context) -> Option<Vec<Sin
     mainloop.lock();
     let introspect = context.introspect();
     let op = introspect.get_server_info(move |info| {
-        *default_sink_cb.lock().unwrap() = info.default_sink_name
-            .as_deref()
-            .map(|s| s.to_string());
+        *default_sink_cb.lock().unwrap() = info.default_sink_name.as_deref().map(|s| s.to_string());
     });
 
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
@@ -400,7 +400,9 @@ fn set_volume(mainloop: &mut Mainloop, context: &Context, name: &str, volume: u3
 
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
     while op.get_state() == libpulse_binding::operation::State::Running {
-        if std::time::Instant::now() > deadline { break; }
+        if std::time::Instant::now() > deadline {
+            break;
+        }
         mainloop.unlock();
         std::thread::sleep(std::time::Duration::from_millis(50));
         mainloop.lock();
@@ -413,7 +415,9 @@ fn set_volume(mainloop: &mut Mainloop, context: &Context, name: &str, volume: u3
     let op = introspect.set_sink_volume_by_name(name, &cvol, None::<Box<dyn FnMut(bool)>>);
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
     while op.get_state() == libpulse_binding::operation::State::Running {
-        if std::time::Instant::now() > deadline { break; }
+        if std::time::Instant::now() > deadline {
+            break;
+        }
         mainloop.unlock();
         std::thread::sleep(std::time::Duration::from_millis(50));
         mainloop.lock();
@@ -427,7 +431,9 @@ fn set_mute(mainloop: &mut Mainloop, context: &Context, name: &str, muted: bool)
     let op = introspect.set_sink_mute_by_name(name, muted, None::<Box<dyn FnMut(bool)>>);
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
     while op.get_state() == libpulse_binding::operation::State::Running {
-        if std::time::Instant::now() > deadline { break; }
+        if std::time::Instant::now() > deadline {
+            break;
+        }
         mainloop.unlock();
         std::thread::sleep(std::time::Duration::from_millis(50));
         mainloop.lock();
@@ -443,7 +449,13 @@ fn pa_sink_to_info(info: &PASinkInfo, default_sink: &Option<String>) -> Option<S
     let name = info.name.as_deref()?.to_string();
     let description = info.description.as_deref().unwrap_or(&name).to_string();
     let enabled = default_sink.as_deref() == Some(name.as_str());
-    info!("[systemvolume] sink '{}' volume={} max={} enabled={}", name, info.volume.avg().0, MAX_VOLUME, enabled);
+    info!(
+        "[systemvolume] sink '{}' volume={} max={} enabled={}",
+        name,
+        info.volume.avg().0,
+        MAX_VOLUME,
+        enabled
+    );
     Some(SinkInfo {
         name,
         description,

--- a/kdeconnect-core/src/plugins/telephony.rs
+++ b/kdeconnect-core/src/plugins/telephony.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
-use base64::{engine::general_purpose, Engine as _};
 use crate::plugins::mpris;
+use base64::{Engine as _, engine::general_purpose};
+use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tracing::info;
 

--- a/kdeconnect-core/src/transport.rs
+++ b/kdeconnect-core/src/transport.rs
@@ -137,7 +137,9 @@ impl TcpTransport {
                                 }
                                 Ok(_) => {
                                     raw.push(byte[0]);
-                                    if byte[0] == b'\n' { break; }
+                                    if byte[0] == b'\n' {
+                                        break;
+                                    }
                                     if raw.len() > 65536 {
                                         warn!(peer = ?peer, "[tcp] identity line too long");
                                         break;
@@ -302,11 +304,17 @@ impl UdpTransport {
                             tracing::error!(
                                 "UDP port {} still in use after {} attempts — \
                                  another instance may be running, exiting: {}",
-                                config.listen_addr.port(), attempts, e
+                                config.listen_addr.port(),
+                                attempts,
+                                e
                             );
                             std::process::exit(1);
                         }
-                        tracing::warn!("UDP bind failed (attempt {}), retrying in 1s: {}", attempts, e);
+                        tracing::warn!(
+                            "UDP bind failed (attempt {}), retrying in 1s: {}",
+                            attempts,
+                            e
+                        );
                         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                     }
                 }
@@ -577,23 +585,72 @@ async fn filtered_identity_for_device(device_id: &str) -> Identity {
     // Map plugin IDs to the capability strings they own.
     // (incoming_caps, outgoing_caps)
     let cap_map: &[(&str, &[&str], &[&str])] = &[
-        ("battery",             &["kdeconnect.battery"],                                                    &["kdeconnect.battery.request"]),
-        ("clipboard",           &["kdeconnect.clipboard", "kdeconnect.clipboard.connect"],                  &["kdeconnect.clipboard"]),
-        ("connectivity_report", &["kdeconnect.connectivity_report"],                                        &[]),
-        ("contacts",            &["kdeconnect.contacts.response_uids_timestamps",
-                                   "kdeconnect.contacts.response_vcards"],                                  &["kdeconnect.contacts.request_all_uids_timestamps",
-                                                                                                              "kdeconnect.contacts.request_vcards_by_uid"]),
-        ("findmyphone",         &[],                                                                        &["kdeconnect.findmyphone.request"]),
-        ("mpris",               &["kdeconnect.mpris", "kdeconnect.mpris.request"],                          &["kdeconnect.mpris", "kdeconnect.mpris.request"]),
-        ("notification",        &["kdeconnect.notification"],                                               &["kdeconnect.notification.request"]),
-        ("ping",                &["kdeconnect.ping"],                                                       &["kdeconnect.ping"]),
-        ("runcommand",          &["kdeconnect.runcommand.request"],                                         &["kdeconnect.runcommand"]),
-        ("share",               &["kdeconnect.share.request"],                                              &["kdeconnect.share.request", "kdeconnect.share.request.update"]),
-        ("sms",                 &["kdeconnect.sms.messages", "kdeconnect.sms.attachment_file"],             &["kdeconnect.sms.request",
-                                                                                                              "kdeconnect.sms.request_conversations",
-                                                                                                              "kdeconnect.sms.request_conversation",
-                                                                                                              "kdeconnect.sms.request_attachment"]),
-        ("telephony",           &["kdeconnect.telephony"],                                                  &["kdeconnect.telephony.request_mute"]),                                                                                                      
+        (
+            "battery",
+            &["kdeconnect.battery"],
+            &["kdeconnect.battery.request"],
+        ),
+        (
+            "clipboard",
+            &["kdeconnect.clipboard", "kdeconnect.clipboard.connect"],
+            &["kdeconnect.clipboard"],
+        ),
+        (
+            "connectivity_report",
+            &["kdeconnect.connectivity_report"],
+            &[],
+        ),
+        (
+            "contacts",
+            &[
+                "kdeconnect.contacts.response_uids_timestamps",
+                "kdeconnect.contacts.response_vcards",
+            ],
+            &[
+                "kdeconnect.contacts.request_all_uids_timestamps",
+                "kdeconnect.contacts.request_vcards_by_uid",
+            ],
+        ),
+        ("findmyphone", &[], &["kdeconnect.findmyphone.request"]),
+        (
+            "mpris",
+            &["kdeconnect.mpris", "kdeconnect.mpris.request"],
+            &["kdeconnect.mpris", "kdeconnect.mpris.request"],
+        ),
+        (
+            "notification",
+            &["kdeconnect.notification"],
+            &["kdeconnect.notification.request"],
+        ),
+        ("ping", &["kdeconnect.ping"], &["kdeconnect.ping"]),
+        (
+            "runcommand",
+            &["kdeconnect.runcommand.request"],
+            &["kdeconnect.runcommand"],
+        ),
+        (
+            "share",
+            &["kdeconnect.share.request"],
+            &[
+                "kdeconnect.share.request",
+                "kdeconnect.share.request.update",
+            ],
+        ),
+        (
+            "sms",
+            &["kdeconnect.sms.messages", "kdeconnect.sms.attachment_file"],
+            &[
+                "kdeconnect.sms.request",
+                "kdeconnect.sms.request_conversations",
+                "kdeconnect.sms.request_conversation",
+                "kdeconnect.sms.request_attachment",
+            ],
+        ),
+        (
+            "telephony",
+            &["kdeconnect.telephony"],
+            &["kdeconnect.telephony.request_mute"],
+        ),
     ];
 
     let mut remove_inc: std::collections::HashSet<&str> = std::collections::HashSet::new();
@@ -611,11 +668,15 @@ async fn filtered_identity_for_device(device_id: &str) -> Identity {
         device_type: base.device_type,
         protocol_version: base.protocol_version,
         tcp_port: base.tcp_port,
-        incoming_capabilities: base.incoming_capabilities.iter()
+        incoming_capabilities: base
+            .incoming_capabilities
+            .iter()
             .filter(|c| !remove_inc.contains(c.as_str()))
             .cloned()
             .collect(),
-        outgoing_capabilities: base.outgoing_capabilities.iter()
+        outgoing_capabilities: base
+            .outgoing_capabilities
+            .iter()
             .filter(|c| !remove_out.contains(c.as_str()))
             .cloned()
             .collect(),

--- a/kdeconnect-dbus-client/src/lib.rs
+++ b/kdeconnect-dbus-client/src/lib.rs
@@ -53,6 +53,7 @@ trait Daemon {
     async fn send_ping(&self, device_id: &str, message: &str) -> zbus::Result<()>;
     async fn send_files(&self, device_id: &str, files: Vec<String>) -> zbus::Result<()>;
     async fn send_clipboard(&self, device_id: &str, content: &str) -> zbus::Result<()>;
+    async fn share_clipboard(&self, device_id: &str) -> zbus::Result<()>;
     async fn ring_device(&self, device_id: &str) -> zbus::Result<()>;
     async fn set_plugin_enabled(
         &self,
@@ -67,6 +68,7 @@ trait Daemon {
     async fn run_command(&self, device_id: &str, key: &str) -> zbus::Result<()>;
     async fn request_run_commands(&self, device_id: &str) -> zbus::Result<()>;
     async fn push_local_commands(&self, device_id: &str) -> zbus::Result<()>;
+    async fn quit(&self) -> zbus::Result<()>;
 
     #[zbus(signal)]
     async fn pairing_requested(&self, device_id: String, device_name: String) -> zbus::Result<()>;
@@ -197,6 +199,11 @@ impl KdeConnectClient {
         Ok(self.daemon_proxy.send_clipboard(device_id, content).await?)
     }
 
+    /// Send the current desktop clipboard using the service's data-control backend.
+    pub async fn share_clipboard(&self, device_id: &str) -> Result<()> {
+        Ok(self.daemon_proxy.share_clipboard(device_id).await?)
+    }
+
     /// Ring a device (findmyphone)
     pub async fn ring_device(&self, device_id: &str) -> Result<()> {
         Ok(self.daemon_proxy.ring_device(device_id).await?)
@@ -247,6 +254,11 @@ impl KdeConnectClient {
         Ok(self.daemon_proxy.push_local_commands(device_id).await?)
     }
 
+    /// Ask the background service to exit cleanly.
+    pub async fn quit(&self) -> Result<()> {
+        Ok(self.daemon_proxy.quit().await?)
+    }
+
     /// Request SMS conversations
     pub async fn request_conversations(&self, device_id: &str) -> Result<()> {
         Ok(self.sms_proxy.request_conversations(device_id).await?)
@@ -261,12 +273,7 @@ impl KdeConnectClient {
     }
 
     /// Send an SMS message
-    pub async fn send_sms(
-        &self,
-        device_id: &str,
-        phone_number: &str,
-        message: &str,
-    ) -> Result<()> {
+    pub async fn send_sms(&self, device_id: &str, phone_number: &str, message: &str) -> Result<()> {
         Ok(self
             .sms_proxy
             .send_sms(device_id, phone_number, message)
@@ -289,9 +296,7 @@ impl KdeConnectClient {
     }
 
     /// Create a stream of service events
-    pub async fn listen_for_events(
-        &self,
-    ) -> futures::stream::BoxStream<'static, ServiceEvent> {
+    pub async fn listen_for_events(&self) -> futures::stream::BoxStream<'static, ServiceEvent> {
         use futures::stream::select_all;
 
         let connected = self
@@ -354,10 +359,7 @@ impl KdeConnectClient {
             .unwrap()
             .map(|s| {
                 let args = s.args().unwrap();
-                ServiceEvent::PairingRequested(
-                    args.device_id.clone(),
-                    args.device_name.clone(),
-                )
+                ServiceEvent::PairingRequested(args.device_id.clone(), args.device_name.clone())
             });
 
         let clipboard = self
@@ -377,11 +379,7 @@ impl KdeConnectClient {
             .unwrap()
             .map(|s| {
                 let args = s.args().unwrap();
-                ServiceEvent::BatteryReceived(
-                    args.device_id.clone(),
-                    args.level,
-                    args.is_charging,
-                )
+                ServiceEvent::BatteryReceived(args.device_id.clone(), args.level, args.is_charging)
             });
 
         let connectivity = self

--- a/kdeconnect-service/Cargo.toml
+++ b/kdeconnect-service/Cargo.toml
@@ -22,3 +22,7 @@ kdeconnect-core = { workspace = true }
 dirs = { workspace = true }
 ron = { workspace = true }
 tracing-appender = { workspace = true }
+calloop = { workspace = true }
+calloop-wayland-source = { workspace = true }
+wayland-client = { workspace = true }
+wayland-protocols = { workspace = true }

--- a/kdeconnect-service/src/clipboard.rs
+++ b/kdeconnect-service/src/clipboard.rs
@@ -1,0 +1,583 @@
+//! Background Wayland clipboard access.
+//!
+//! A panel applet cannot reliably use `wl_data_device`: reads and writes are
+//! tied to keyboard focus and an input serial.  This worker uses the privileged
+//! `ext-data-control-v1` protocol on a separate connection instead, so clipboard
+//! synchronization is independent of popup focus and of the applet process.
+
+use anyhow::{Context, Result, anyhow};
+use calloop::{EventLoop, channel};
+use calloop_wayland_source::WaylandSource;
+use std::{
+    collections::{HashMap, HashSet},
+    fs::File,
+    io::{Read, Write},
+    os::fd::{AsFd, BorrowedFd},
+    os::unix::net::UnixStream,
+    path::PathBuf,
+    sync::{Arc, RwLock},
+};
+use tokio::sync::mpsc;
+use tracing::{debug, info, warn};
+use wayland_client::{
+    Connection, Dispatch, Proxy, QueueHandle,
+    backend::ObjectId,
+    delegate_noop,
+    protocol::{wl_registry, wl_seat},
+};
+use wayland_protocols::ext::data_control::v1::client::{
+    ext_data_control_device_v1::{self, ExtDataControlDeviceV1},
+    ext_data_control_manager_v1::ExtDataControlManagerV1,
+    ext_data_control_offer_v1::{self, ExtDataControlOfferV1},
+    ext_data_control_source_v1::{self, ExtDataControlSourceV1},
+};
+
+const TEXT_MIME_TYPES: &[&str] = &[
+    "text/plain;charset=utf-8",
+    "text/plain;charset=UTF-8",
+    "UTF8_STRING",
+    "text/plain",
+    "STRING",
+];
+const MAX_CLIPBOARD_BYTES: u64 = 16 * 1024 * 1024;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClipboardContent {
+    pub text: String,
+    pub sensitive: bool,
+}
+
+#[derive(Debug)]
+pub enum ClipboardEvent {
+    /// A user/application changed the regular desktop clipboard.  Changes made
+    /// through `ClipboardHandle::set_text` are intentionally not emitted.
+    Changed(ClipboardContent),
+}
+
+#[derive(Clone, Debug)]
+pub struct ClipboardHandle {
+    commands: channel::Sender<Command>,
+    current: Arc<RwLock<Option<ClipboardContent>>>,
+}
+
+impl ClipboardHandle {
+    pub fn current(&self) -> Option<ClipboardContent> {
+        self.current.read().ok().and_then(|value| value.clone())
+    }
+
+    pub fn set_text(&self, text: String) -> Result<()> {
+        if text.is_empty() {
+            return Err(anyhow!("refusing to replace the clipboard with empty text"));
+        }
+        self.commands
+            .send(Command::SetText(text))
+            .map_err(|_| anyhow!("clipboard worker has stopped"))
+    }
+}
+
+#[derive(Debug)]
+enum Command {
+    SetText(String),
+    SelectionRead {
+        generation: u64,
+        publish: bool,
+        content: Option<ClipboardContent>,
+    },
+}
+
+#[derive(Default)]
+struct OfferState {
+    mime_types: Vec<String>,
+}
+
+struct WorkerState {
+    manager: Option<ExtDataControlManagerV1>,
+    seats: HashMap<ObjectId, wl_seat::WlSeat>,
+    devices: HashMap<ObjectId, ExtDataControlDeviceV1>,
+    offers: HashMap<ObjectId, OfferState>,
+    sources: HashMap<ObjectId, String>,
+    selection_offer: Option<ExtDataControlOfferV1>,
+    selection_generation: u64,
+    initialized_devices: HashSet<ObjectId>,
+    pending_remote_write: Option<String>,
+    commands: channel::Sender<Command>,
+    events: mpsc::UnboundedSender<ClipboardEvent>,
+    current: Arc<RwLock<Option<ClipboardContent>>>,
+}
+
+impl WorkerState {
+    fn ensure_devices(&mut self, qh: &QueueHandle<Self>) {
+        let Some(manager) = self.manager.as_ref() else {
+            return;
+        };
+
+        for (seat_id, seat) in &self.seats {
+            if !self.devices.contains_key(seat_id) {
+                let device = manager.get_data_device(seat, qh, ());
+                self.devices.insert(seat_id.clone(), device);
+            }
+        }
+    }
+
+    fn handle_command(&mut self, command: Command, qh: &QueueHandle<Self>) {
+        match command {
+            Command::SetText(text) => self.set_text(text, qh),
+            Command::SelectionRead {
+                generation,
+                publish,
+                content,
+            } => self.finish_selection_read(generation, publish, content),
+        }
+    }
+
+    fn set_text(&mut self, text: String, qh: &QueueHandle<Self>) {
+        let Some(manager) = self.manager.as_ref() else {
+            warn!("Cannot write clipboard: ext-data-control manager disappeared");
+            return;
+        };
+
+        if self.devices.is_empty() {
+            warn!("Cannot write clipboard: compositor did not advertise a seat");
+            return;
+        }
+
+        for device in self.devices.values() {
+            // A data-control source may only be used in one set_selection
+            // request, so every seat gets its own source.
+            let source = manager.create_data_source(qh, ());
+            for mime_type in TEXT_MIME_TYPES {
+                source.offer((*mime_type).to_string());
+            }
+            self.sources.insert(source.id(), text.clone());
+            device.set_selection(Some(&source));
+        }
+
+        self.pending_remote_write = Some(text.clone());
+        if let Ok(mut current) = self.current.write() {
+            *current = Some(ClipboardContent {
+                text,
+                sensitive: false,
+            });
+        }
+    }
+
+    fn begin_selection_read(
+        &mut self,
+        offer: Option<ExtDataControlOfferV1>,
+        publish: bool,
+        connection: &Connection,
+    ) {
+        self.selection_generation = self.selection_generation.wrapping_add(1);
+        let generation = self.selection_generation;
+
+        if let Some(previous) = self.selection_offer.take() {
+            self.offers.remove(&previous.id());
+            previous.destroy();
+        }
+
+        let Some(offer) = offer else {
+            self.finish_selection_read(generation, publish, None);
+            return;
+        };
+
+        let offer_state = self.offers.get(&offer.id());
+        let mime_type = TEXT_MIME_TYPES.iter().find_map(|preferred| {
+            offer_state?
+                .mime_types
+                .iter()
+                .find(|offered| offered.eq_ignore_ascii_case(preferred))
+                .cloned()
+        });
+        let sensitive = offer_state.is_some_and(|state| {
+            state.mime_types.iter().any(|mime| {
+                mime.eq_ignore_ascii_case("application/x-kde-passwordmanagerhint")
+                    || mime.eq_ignore_ascii_case("x-kde-passwordmanagerhint")
+            })
+        });
+        self.selection_offer = Some(offer.clone());
+
+        let Some(mime_type) = mime_type else {
+            self.finish_selection_read(generation, publish, None);
+            return;
+        };
+
+        let Ok((mut reader, writer)) = UnixStream::pair() else {
+            warn!("Failed to create clipboard transfer socket");
+            self.finish_selection_read(generation, publish, None);
+            return;
+        };
+
+        offer.receive(mime_type, writer.as_fd());
+        if let Err(error) = connection.flush() {
+            warn!("Failed to start clipboard transfer: {error}");
+            self.finish_selection_read(generation, publish, None);
+            return;
+        }
+        drop(writer);
+
+        let commands = self.commands.clone();
+        std::thread::spawn(move || {
+            let mut bytes = Vec::new();
+            let content = match Read::by_ref(&mut reader)
+                .take(MAX_CLIPBOARD_BYTES + 1)
+                .read_to_end(&mut bytes)
+            {
+                Ok(_) if bytes.len() as u64 > MAX_CLIPBOARD_BYTES => {
+                    warn!("Clipboard selection exceeds the 16 MiB safety limit");
+                    None
+                }
+                Ok(_) => match String::from_utf8(bytes) {
+                    Ok(text) if !text.is_empty() => Some(ClipboardContent { text, sensitive }),
+                    Ok(_) => None,
+                    Err(error) => {
+                        warn!("Clipboard selection is not valid UTF-8: {error}");
+                        None
+                    }
+                },
+                Err(error) => {
+                    warn!("Failed to read clipboard selection: {error}");
+                    None
+                }
+            };
+            let _ = commands.send(Command::SelectionRead {
+                generation,
+                publish,
+                content,
+            });
+        });
+    }
+
+    fn finish_selection_read(
+        &mut self,
+        generation: u64,
+        publish: bool,
+        content: Option<ClipboardContent>,
+    ) {
+        // A slow owner may finish after a newer clipboard selection was made.
+        if generation != self.selection_generation {
+            return;
+        }
+
+        let previous = self.current.read().ok().and_then(|value| value.clone());
+        if let Ok(mut current) = self.current.write() {
+            *current = content.clone();
+        }
+
+        let Some(content) = content else {
+            self.pending_remote_write = None;
+            return;
+        };
+
+        if self.pending_remote_write.as_deref() == Some(&content.text) {
+            self.pending_remote_write = None;
+            debug!("Suppressed clipboard echo after phone-to-desktop update");
+            return;
+        }
+        self.pending_remote_write = None;
+
+        // Multiple seats and clipboard owners replacing themselves can produce
+        // duplicate selection events for identical text.
+        if previous.as_ref() == Some(&content) {
+            return;
+        }
+
+        // Do not send whatever happened to be in the clipboard before the
+        // service started. Only later user/application changes are synchronized.
+        if publish {
+            let _ = self.events.send(ClipboardEvent::Changed(content));
+        }
+    }
+}
+
+impl Dispatch<wl_registry::WlRegistry, ()> for WorkerState {
+    fn event(
+        state: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        match event {
+            wl_registry::Event::Global {
+                name,
+                interface,
+                version,
+            } if interface == ExtDataControlManagerV1::interface().name => {
+                state.manager = Some(registry.bind(name, version.min(1), qh, ()));
+                state.ensure_devices(qh);
+            }
+            wl_registry::Event::Global {
+                name,
+                interface,
+                version,
+            } if interface == wl_seat::WlSeat::interface().name => {
+                let seat: wl_seat::WlSeat = registry.bind(name, version.min(9), qh, ());
+                state.seats.insert(seat.id(), seat);
+                state.ensure_devices(qh);
+            }
+            _ => {}
+        }
+    }
+}
+
+delegate_noop!(WorkerState: ignore wl_seat::WlSeat);
+delegate_noop!(WorkerState: ignore ExtDataControlManagerV1);
+
+impl Dispatch<ExtDataControlDeviceV1, ()> for WorkerState {
+    fn event(
+        state: &mut Self,
+        device: &ExtDataControlDeviceV1,
+        event: ext_data_control_device_v1::Event,
+        _: &(),
+        connection: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        match event {
+            ext_data_control_device_v1::Event::Selection { id } => {
+                // Every seat sends one initial selection snapshot. It seeds the
+                // cache but must not be mistaken for a user clipboard change.
+                let publish = !state.initialized_devices.insert(device.id());
+                state.begin_selection_read(id, publish, connection);
+            }
+            ext_data_control_device_v1::Event::Finished => {
+                warn!("Wayland compositor revoked clipboard data-control access");
+            }
+            // Primary selection is intentionally independent from Ctrl+C/Ctrl+V.
+            ext_data_control_device_v1::Event::DataOffer { .. }
+            | ext_data_control_device_v1::Event::PrimarySelection { .. } => {}
+            _ => {}
+        }
+    }
+
+    fn event_created_child(
+        opcode: u16,
+        qh: &QueueHandle<Self>,
+    ) -> Arc<dyn wayland_client::backend::ObjectData> {
+        match opcode {
+            0 => qh.make_data::<ExtDataControlOfferV1, _>(()),
+            _ => unreachable!("unknown ext_data_control_device_v1 child opcode"),
+        }
+    }
+}
+
+impl Dispatch<ExtDataControlOfferV1, ()> for WorkerState {
+    fn event(
+        state: &mut Self,
+        offer: &ExtDataControlOfferV1,
+        event: ext_data_control_offer_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let ext_data_control_offer_v1::Event::Offer { mime_type } = event {
+            state
+                .offers
+                .entry(offer.id())
+                .or_default()
+                .mime_types
+                .push(mime_type);
+        }
+    }
+}
+
+impl Dispatch<ExtDataControlSourceV1, ()> for WorkerState {
+    fn event(
+        state: &mut Self,
+        source: &ExtDataControlSourceV1,
+        event: ext_data_control_source_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        match event {
+            ext_data_control_source_v1::Event::Send { fd, .. } => {
+                let Some(text) = state.sources.get(&source.id()).cloned() else {
+                    return;
+                };
+                std::thread::spawn(move || {
+                    let mut file = File::from(fd);
+                    if let Err(error) = file.write_all(text.as_bytes()) {
+                        warn!("Failed to serve clipboard data: {error}");
+                    }
+                });
+            }
+            ext_data_control_source_v1::Event::Cancelled => {
+                state.sources.remove(&source.id());
+                source.destroy();
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Start the clipboard worker. Failure is non-fatal: the KDE Connect network
+/// service remains usable and manual clipboard actions return a clear error.
+pub fn start() -> Result<(ClipboardHandle, mpsc::UnboundedReceiver<ClipboardEvent>)> {
+    let connection = connect_to_host_compositor()?;
+    let mut event_queue = connection.new_event_queue::<WorkerState>();
+    let qh = event_queue.handle();
+    connection.display().get_registry(&qh, ());
+
+    let (command_sender, command_channel) = channel::channel();
+    let (event_sender, event_receiver) = mpsc::unbounded_channel();
+    let current = Arc::new(RwLock::new(None));
+    let mut state = WorkerState {
+        manager: None,
+        seats: HashMap::new(),
+        devices: HashMap::new(),
+        offers: HashMap::new(),
+        sources: HashMap::new(),
+        selection_offer: None,
+        selection_generation: 0,
+        initialized_devices: HashSet::new(),
+        pending_remote_write: None,
+        commands: command_sender.clone(),
+        events: event_sender,
+        current: current.clone(),
+    };
+
+    event_queue
+        .roundtrip(&mut state)
+        .context("failed to enumerate Wayland clipboard globals")?;
+    event_queue
+        .roundtrip(&mut state)
+        .context("failed to initialize Wayland data-control device")?;
+
+    if state.manager.is_none() {
+        return Err(anyhow!(
+            "the compositor does not advertise ext-data-control-v1"
+        ));
+    }
+    if state.devices.is_empty() {
+        return Err(anyhow!("the compositor did not advertise a Wayland seat"));
+    }
+
+    let handle = ClipboardHandle {
+        commands: command_sender,
+        current,
+    };
+
+    std::thread::Builder::new()
+        .name("kdeconnect-clipboard".to_string())
+        .spawn(move || {
+            let mut event_loop: EventLoop<WorkerState> = match EventLoop::try_new() {
+                Ok(event_loop) => event_loop,
+                Err(error) => {
+                    warn!("Failed to create clipboard event loop: {error}");
+                    return;
+                }
+            };
+            let loop_handle = event_loop.handle();
+            if let Err(error) =
+                WaylandSource::new(connection, event_queue).insert(loop_handle.clone())
+            {
+                warn!("Failed to register clipboard Wayland source: {error}");
+                return;
+            }
+            if let Err(error) =
+                loop_handle.insert_source(command_channel, |event, _, state| match event {
+                    channel::Event::Msg(command) => state.handle_command(command, &qh),
+                    channel::Event::Closed => {}
+                })
+            {
+                warn!("Failed to register clipboard command source: {error}");
+                return;
+            }
+
+            info!("Wayland ext-data-control clipboard worker started");
+            if let Err(error) = event_loop.run(None, &mut state, |_| {}) {
+                warn!("Clipboard worker stopped: {error}");
+            }
+        })
+        .context("failed to spawn clipboard worker thread")?;
+
+    Ok((handle, event_receiver))
+}
+
+fn connect_to_host_compositor() -> Result<Connection> {
+    if let Ok(raw_fd) = std::env::var("X_PRIVILEGED_WAYLAND_SOCKET") {
+        if let Ok(raw_fd) = raw_fd.parse::<i32>() {
+            // The panel owns the inherited descriptor. Duplicate it so this
+            // connection can close independently from the applet/panel.
+            let borrowed = unsafe { BorrowedFd::borrow_raw(raw_fd) };
+            if let Ok(owned) = borrowed.try_clone_to_owned() {
+                let stream = UnixStream::from(owned);
+                return Connection::from_socket(stream)
+                    .context("failed to connect through X_PRIVILEGED_WAYLAND_SOCKET");
+            }
+        }
+        warn!("Ignoring invalid X_PRIVILEGED_WAYLAND_SOCKET");
+    }
+
+    let display = std::env::var_os("WAYLAND_DISPLAY")
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow!("WAYLAND_DISPLAY is not set"))?;
+    let socket_path = if display.is_absolute() {
+        display
+    } else {
+        let runtime_dir = std::env::var_os("XDG_RUNTIME_DIR")
+            .map(PathBuf::from)
+            .ok_or_else(|| anyhow!("XDG_RUNTIME_DIR is not set"))?;
+        runtime_dir.join(display)
+    };
+    let stream = UnixStream::connect(&socket_path)
+        .with_context(|| format!("failed to connect to {}", socket_path.display()))?;
+    Connection::from_socket(stream).context("failed to initialize Wayland connection")
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ClipboardPluginConfig {
+    pub auto_share: bool,
+    pub send_password: bool,
+}
+
+impl Default for ClipboardPluginConfig {
+    fn default() -> Self {
+        Self {
+            auto_share: true,
+            send_password: false,
+        }
+    }
+}
+
+/// Read the same per-device KDE config that the settings UI writes. Keeping
+/// this parser in the service makes auto-sync independent of applet lifetime.
+pub async fn load_plugin_config(device_id: &str) -> ClipboardPluginConfig {
+    let path = dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("kdeconnect")
+        .join(device_id)
+        .join("kdeconnect_clipboard")
+        .join("config");
+    let Ok(contents) = tokio::fs::read_to_string(path).await else {
+        return ClipboardPluginConfig::default();
+    };
+
+    let mut config = ClipboardPluginConfig::default();
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with('[') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        match key.trim() {
+            "autoShare" => config.auto_share = value.trim().parse().unwrap_or(true),
+            "sendPassword" => config.send_password = value.trim().parse().unwrap_or(false),
+            _ => {}
+        }
+    }
+    config
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[ignore = "requires a running Wayland compositor with ext-data-control-v1"]
+    fn data_control_smoke() {
+        let (_handle, _events) =
+            super::start().expect("the current Wayland session must provide ext-data-control-v1");
+    }
+}

--- a/kdeconnect-service/src/dbus_interface.rs
+++ b/kdeconnect-service/src/dbus_interface.rs
@@ -15,6 +15,8 @@ use tracing::{debug, error, info};
 use zbus::object_server::SignalEmitter;
 use zbus::{Connection, interface};
 
+use crate::clipboard::{self, ClipboardEvent, ClipboardHandle};
+
 const SERVICE_NAME: &str = "io.github.hepp3n.kdeconnect";
 const DAEMON_PATH: &str = "/io/github/hepp3n/kdeconnect/Daemon";
 const SMS_PATH: &str = "/io/github/hepp3n/kdeconnect/Sms";
@@ -121,6 +123,8 @@ async fn load_sms_cache(device_id: &str) -> Option<String> {
 pub struct DaemonInterface {
     event_sender: Arc<mpsc::UnboundedSender<AppEvent>>,
     devices: Arc<Mutex<HashMap<String, DbusDevice>>>,
+    shutdown_sender: tokio::sync::watch::Sender<bool>,
+    clipboard: Option<ClipboardHandle>,
 }
 
 #[interface(name = "io.github.hepp3n.kdeconnect.Daemon")]
@@ -181,11 +185,67 @@ impl DaemonInterface {
     /// Send clipboard content
     async fn send_clipboard(&self, device_id: String, content: String) -> zbus::fdo::Result<()> {
         info!("D-Bus: SendClipboard called for {}", device_id);
+
+        let device = self.devices.lock().await.get(&device_id).cloned();
+        let Some(device) = device else {
+            return Err(zbus::fdo::Error::Failed(format!(
+                "Unknown device: {device_id}"
+            )));
+        };
+        if !device.is_paired {
+            return Err(zbus::fdo::Error::Failed(format!(
+                "Device is not paired: {device_id}"
+            )));
+        }
+        if !device.is_reachable {
+            return Err(zbus::fdo::Error::Failed(format!(
+                "Device is not reachable: {device_id}"
+            )));
+        }
+        if kdeconnect_core::plugin_config::load_disabled_plugins(&device_id)
+            .await
+            .contains("clipboard")
+        {
+            return Err(zbus::fdo::Error::Failed(format!(
+                "Clipboard plugin is disabled for device: {device_id}"
+            )));
+        }
+
         let packet = ProtocolPacket::new(PacketType::Clipboard, json!({ "content": content }));
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
         self.event_sender
-            .send(AppEvent::SendPacket(DeviceId(device_id), packet))
+            .send(AppEvent::SendPacketWithReply(
+                DeviceId(device_id),
+                packet,
+                reply_tx,
+            ))
             .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
-        Ok(())
+
+        match tokio::time::timeout(std::time::Duration::from_secs(2), reply_rx).await {
+            Ok(Ok(Ok(()))) => Ok(()),
+            Ok(Ok(Err(message))) => Err(zbus::fdo::Error::Failed(message)),
+            Ok(Err(_)) => Err(zbus::fdo::Error::Failed(
+                "Clipboard send acknowledgement was dropped".to_string(),
+            )),
+            Err(_) => Err(zbus::fdo::Error::Failed(
+                "Clipboard send acknowledgement timed out".to_string(),
+            )),
+        }
+    }
+
+    /// Send the current desktop clipboard. Reading is performed by the
+    /// service's background data-control worker, not by the focused applet.
+    async fn share_clipboard(&self, device_id: String) -> zbus::fdo::Result<()> {
+        let clipboard = self.clipboard.as_ref().ok_or_else(|| {
+            zbus::fdo::Error::Failed(
+                "Background clipboard access is unavailable; ext-data-control-v1 is required"
+                    .to_string(),
+            )
+        })?;
+        let content = clipboard.current().ok_or_else(|| {
+            zbus::fdo::Error::Failed("The current clipboard does not contain text".to_string())
+        })?;
+        self.send_clipboard(device_id, content.text).await
     }
 
     /// Ring a device (findmyphone)
@@ -232,6 +292,17 @@ impl DaemonInterface {
         }
     }
 
+    /// Stop the daemon. The short delay lets zbus flush the method reply before
+    /// the process releases its session-bus connection.
+    async fn quit(&self) {
+        info!("D-Bus: Quit called");
+        let shutdown_sender = self.shutdown_sender.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            let _ = shutdown_sender.send(true);
+        });
+    }
+
     /// Trigger a UDP identity broadcast to discover nearby devices.
     async fn broadcast_identity(&self) -> zbus::fdo::Result<()> {
         info!("D-Bus: BroadcastIdentity called");
@@ -245,7 +316,9 @@ impl DaemonInterface {
     async fn accept_pairing(&self, device_id: String) -> zbus::fdo::Result<()> {
         info!("D-Bus: AcceptPairing called for {}", device_id);
         self.event_sender
-            .send(AppEvent::AcceptPairing(kdeconnect_core::device::DeviceId(device_id)))
+            .send(AppEvent::AcceptPairing(kdeconnect_core::device::DeviceId(
+                device_id,
+            )))
             .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
         Ok(())
     }
@@ -254,7 +327,9 @@ impl DaemonInterface {
     async fn reject_pairing(&self, device_id: String) -> zbus::fdo::Result<()> {
         info!("D-Bus: RejectPairing called for {}", device_id);
         self.event_sender
-            .send(AppEvent::RejectPairing(kdeconnect_core::device::DeviceId(device_id)))
+            .send(AppEvent::RejectPairing(kdeconnect_core::device::DeviceId(
+                device_id,
+            )))
             .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
         Ok(())
     }
@@ -323,10 +398,7 @@ impl DaemonInterface {
     /// Execute a remote command on a device by key
     async fn run_command(&self, device_id: String, key: String) -> zbus::fdo::Result<()> {
         info!("D-Bus: RunCommand called for {} key={}", device_id, key);
-        let packet = ProtocolPacket::new(
-            PacketType::RunCommandRequest,
-            json!({ "key": key }),
-        );
+        let packet = ProtocolPacket::new(PacketType::RunCommandRequest, json!({ "key": key }));
         self.event_sender
             .send(AppEvent::SendPacket(DeviceId(device_id), packet))
             .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
@@ -351,7 +423,9 @@ impl DaemonInterface {
     async fn push_local_commands(&self, device_id: String) -> zbus::fdo::Result<()> {
         info!("D-Bus: PushLocalCommands called for {}", device_id);
         self.event_sender
-            .send(AppEvent::PushLocalCommands(kdeconnect_core::device::DeviceId(device_id)))
+            .send(AppEvent::PushLocalCommands(
+                kdeconnect_core::device::DeviceId(device_id),
+            ))
             .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
         Ok(())
     }
@@ -505,6 +579,7 @@ pub struct KdeConnectService {
     event_sender: Arc<mpsc::UnboundedSender<AppEvent>>,
     #[allow(dead_code)]
     devices: Arc<Mutex<HashMap<String, DbusDevice>>>,
+    shutdown_receiver: tokio::sync::watch::Receiver<bool>,
 }
 
 impl KdeConnectService {
@@ -522,6 +597,18 @@ impl KdeConnectService {
         use tokio::signal::unix::{SignalKind, signal};
 
         let mut sigterm = signal(SignalKind::terminate())?;
+        let mut shutdown_receiver = self.shutdown_receiver.clone();
+
+        let shutdown_requested = async move {
+            loop {
+                if *shutdown_receiver.borrow() {
+                    break;
+                }
+                if shutdown_receiver.changed().await.is_err() {
+                    std::future::pending::<()>().await;
+                }
+            }
+        };
 
         // Dedicated watch connection — no messages are expected on it.
         // When the session bus closes (cosmic-session logout or systemd user
@@ -539,6 +626,7 @@ impl KdeConnectService {
             _ = tokio::signal::ctrl_c() => { info!("SIGINT received, shutting down"); }
             _ = sigterm.recv() => { info!("SIGTERM received, shutting down"); }
             _ = session_ended => { info!("Session D-Bus closed, shutting down"); }
+            _ = shutdown_requested => { info!("Quit requested over D-Bus, shutting down"); }
         }
         Ok(())
     }
@@ -562,6 +650,15 @@ impl KdeConnectService {
         info!("kdeconnect-core initialized");
 
         let devices = Arc::new(Mutex::new(HashMap::new()));
+        let (shutdown_sender, shutdown_receiver) = tokio::sync::watch::channel(false);
+
+        let (clipboard, clipboard_events) = match clipboard::start() {
+            Ok((handle, events)) => (Some(handle), Some(events)),
+            Err(error) => {
+                error!("Background clipboard synchronization unavailable: {error:#}");
+                (None, None)
+            }
+        };
 
         // Pre-populate known paired devices as offline so list_devices() returns
         // them immediately after reboot, before the phone actively reconnects.
@@ -600,6 +697,8 @@ impl KdeConnectService {
         let daemon_interface = DaemonInterface {
             event_sender: event_sender.clone(),
             devices: devices.clone(),
+            shutdown_sender,
+            clipboard: clipboard.clone(),
         };
         connection
             .object_server()
@@ -654,6 +753,51 @@ impl KdeConnectService {
             }
         });
 
+        if let Some(mut clipboard_events) = clipboard_events {
+            let devices = devices.clone();
+            let event_sender = event_sender.clone();
+            tokio::spawn(async move {
+                while let Some(event) = clipboard_events.recv().await {
+                    let ClipboardEvent::Changed(content) = event;
+                    let candidates: Vec<DbusDevice> = devices
+                        .lock()
+                        .await
+                        .values()
+                        .filter(|device| device.is_paired && device.is_reachable)
+                        .cloned()
+                        .collect();
+
+                    for device in candidates {
+                        if kdeconnect_core::plugin_config::load_disabled_plugins(&device.id)
+                            .await
+                            .contains("clipboard")
+                        {
+                            continue;
+                        }
+                        let config = clipboard::load_plugin_config(&device.id).await;
+                        if !config.auto_share || (content.sensitive && !config.send_password) {
+                            continue;
+                        }
+
+                        let packet = ProtocolPacket::new(
+                            PacketType::Clipboard,
+                            json!({ "content": content.text }),
+                        );
+                        if let Err(error) = event_sender
+                            .send(AppEvent::SendPacket(DeviceId(device.id.clone()), packet))
+                        {
+                            error!(
+                                "Failed to queue automatic clipboard for {}: {error}",
+                                device.id
+                            );
+                        } else {
+                            debug!("Automatic clipboard queued for {}", device.id);
+                        }
+                    }
+                }
+            });
+        }
+
         let core_handle = tokio::spawn(async move {
             core.run_event_loop().await;
         });
@@ -661,7 +805,9 @@ impl KdeConnectService {
         tokio::spawn(async move {
             match core_handle.await {
                 Ok(_) => error!("Core event loop exited unexpectedly - connections will fail"),
-                Err(e) if e.is_panic() => error!("Core event loop PANICKED - connections will fail: {:?}", e),
+                Err(e) if e.is_panic() => {
+                    error!("Core event loop PANICKED - connections will fail: {:?}", e)
+                }
                 Err(e) => error!("Core event loop cancelled: {:?}", e),
             }
         });
@@ -670,6 +816,7 @@ impl KdeConnectService {
             connection,
             event_sender,
             devices,
+            shutdown_receiver,
         })
     }
 
@@ -830,7 +977,10 @@ impl KdeConnectService {
                 debug!("Device disconnected signal emitted");
             }
             ConnectionEvent::PairStateChanged((device_id, pair_state)) => {
-                info!("Event: PairStateChanged - {} → {:?}", device_id.0, pair_state);
+                info!(
+                    "Event: PairStateChanged - {} → {:?}",
+                    device_id.0, pair_state
+                );
                 let is_paired = matches!(pair_state, PairState::Paired);
 
                 {
@@ -936,8 +1086,16 @@ impl KdeConnectService {
                     .object_server()
                     .interface::<_, DaemonInterface>(DAEMON_PATH)
                     .await?;
-                DaemonInterface::clipboard_received(iface_ref.signal_emitter(), content)
-                    .await?;
+                let clipboard = { iface_ref.get().await.clipboard.clone() };
+                if let Some(clipboard) = clipboard {
+                    if let Err(error) = clipboard.set_text(content.clone()) {
+                        error!("Failed to write phone clipboard to desktop: {error}");
+                    }
+                } else {
+                    error!("Cannot write phone clipboard: background clipboard access unavailable");
+                }
+
+                DaemonInterface::clipboard_received(iface_ref.signal_emitter(), content).await?;
                 debug!("ClipboardReceived D-Bus signal emitted");
             }
             ConnectionEvent::StateUpdated(state) => {

--- a/kdeconnect-service/src/main.rs
+++ b/kdeconnect-service/src/main.rs
@@ -3,6 +3,7 @@
 use anyhow::Result;
 use tracing::info;
 
+mod clipboard;
 mod dbus_interface;
 
 #[tokio::main]
@@ -17,8 +18,7 @@ async fn main() -> Result<()> {
     if std::env::var("KDECONNECT_LOG_FILE").is_ok()
         && std::path::Path::new("/.flatpak-info").exists()
     {
-        let log_dir = dirs::data_dir()
-            .unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
+        let log_dir = dirs::data_dir().unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
         let _ = std::fs::create_dir_all(&log_dir);
         let file = std::fs::OpenOptions::new()
             .create(true)


### PR DESCRIPTION
## Summary

This PR reworks clipboard synchronization so it is handled by the background service instead of the applet UI process.

The previous implementation used the applet clipboard API. It worked in some debug scenarios, but was unreliable for phone-to-PC clipboard updates under Wayland.

## Changes

- Added a background Wayland clipboard worker using `ext-data-control-v1`
- Moved phone-to-PC clipboard writes into `kdeconnect-service`
- Added manual PC-to-phone clipboard sharing through the service
- Added acknowledgement/error handling for clipboard packet sending
- Added a right-click Quit action for the applet/service
- Some justfile fixes: `rm -vf {{PREFIX}}/share/kdeconnect/*` falled back with errors because of directories 

## Testing

- `cargo fmt`
- `cargo test`
- Manual test with a paired phone:
  - phone - PC clipboard sync works
  - PC - phone clipboard share works
  - applet restart/debug run no longer keeps using a stale service

## Configuration

Pixel 7a
Pop!_OS 24.04 LTS, "cosmic-panel/noble,now 0.1.0~1782157529~24.04~45f03a3"

## AI usage

codex + gpt-5.5-xhigh, that helped with the coding and translation. 